### PR TITLE
Add scan and stream read to append store interface

### DIFF
--- a/src/main/java/com/upserve/uppend/AppendOnlyStore.java
+++ b/src/main/java/com/upserve/uppend/AppendOnlyStore.java
@@ -1,6 +1,7 @@
 package com.upserve.uppend;
 
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 
 /**
  * Defines the minimum interface required to add byte arrays under a key, and to
@@ -15,7 +16,7 @@ public interface AppendOnlyStore extends AutoCloseable {
      * @param value the value to append
      */
     void append(String key, byte[] value);
-
+    
     /**
      * Read byte arrays that have been stored under a given key
      *
@@ -23,6 +24,20 @@ public interface AppendOnlyStore extends AutoCloseable {
      * @param reader function to be called once per stored byte array
      */
     void read(String key, Consumer<byte[]> reader);
+
+    /**
+     * Read byte arrays that have been stored under a given key as a stream
+     *
+     * @param key the key under which to retrieve
+     */
+    Stream<byte[]> read(String key);
+
+    /**
+     * Stream of the keys in the append store instance
+     *
+     * @param prefix the key prefix for a set of stored objects. All keys if null.
+     */
+    Stream<String> scan(String prefix);
 
     /**
      * Remove all keys and values from the store.


### PR DESCRIPTION
@bfulton @kbarrette 
CC @mguymon 

Here is a straw-man for the interface changes we need in the append store.
I have added a scan method and a second read method both of which return a stream.

If these build a collection and then stream it underneath that is fine for now, but eventually I think we would want to do something smarter that does not involve completing the operation for the entire collection of results before returning the result.

Also not sure if we need interface changes to accommodate the key and prefix in the read or append operations. I think this could entirely an implementation details in how keys are parsed and stored, but it leaks into the scan operation where I want to be able to specify a prefix to scan.