### PR TITLE
Always cache lookups

### DIFF
--- a/src/main/java/com/upserve/uppend/FileAppendOnlyStore.java
+++ b/src/main/java/com/upserve/uppend/FileAppendOnlyStore.java
@@ -33,8 +33,7 @@ public class FileAppendOnlyStore implements AppendOnlyStore {
         validatePartition(partition);
 
         long blobPos = blobs.append(value);
-        LongLookup lookup = lookups.get(partition, key);
-        long blockPos = lookup.putIfNotExists(key, blocks::allocate);
+        long blockPos = lookups.putIfNotExists(partition, key, blocks::allocate);
         log.trace("appending {} bytes (blob pos {}) for key '{}' at block pos {}", value.length, blobPos, key, blockPos);
         blocks.append(blockPos, blobPos);
     }

--- a/src/main/java/com/upserve/uppend/HashedLongLookups.java
+++ b/src/main/java/com/upserve/uppend/HashedLongLookups.java
@@ -10,6 +10,7 @@ import java.nio.file.*;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.concurrent.TimeUnit;
+import java.util.function.LongSupplier;
 import java.util.stream.Stream;
 
 @Slf4j
@@ -46,8 +47,8 @@ public class HashedLongLookups implements AutoCloseable {
                 .build(LongLookup::new);
     }
 
-    public LongLookup get(String partition, String key) {
-        return cache.get(hashPath(partition, key));
+    public long putIfNotExists(String partition, String key, LongSupplier allocateLongFunc) {
+        return longLookup(partition, key).putIfNotExists(key, allocateLongFunc);
     }
 
     public Long getValue(String partition, String key) {


### PR DESCRIPTION
@bfulton @dstuebe 

I think this may fix https://github.com/upserve/uppend/issues/12

It looks to me like the problem is caused by a `LongLookup` being written while `scan` is running to instantiate a new one. My solution was to force every `LongLookup` to move through the cache in `HashedLongLookups`, causing there to be only a single instance in use at any time.

Repercussions:
1. The Caffeine cache now no longer has a threaded executor, since I need to know that old `LongLookup` instances are closed before allowing them to be recreated
2. We'll be turning over the cache more often, which will have performance implications

A few other possibilities:
1. Retry `scan` when it fails, hoping to avoid the race
2. Allow `scan` to succeed even if the underlying file changes, but only when the resulting object is to be used for reading (not sure if this will work...)