### PR TITLE
check for LongLookup dir before trying to remove it, add tests for clear then close

### DIFF
--- a/src/main/java/com/upserve/uppend/lookup/LongLookup.java
+++ b/src/main/java/com/upserve/uppend/lookup/LongLookup.java
@@ -231,10 +231,12 @@ public class LongLookup implements AutoCloseable, Flushable {
         log.info("clearing {}", dir);
         close();
         try {
-            Path tmpDir = Files.createTempFile(dir.getParent(), dir.getFileName().toString(), ".defunct");
-            Files.delete(tmpDir);
-            Files.move(dir, tmpDir);
-            SafeDeleting.removeDirectory(tmpDir);
+            if (Files.exists(dir)) {
+                Path tmpDir = Files.createTempFile(dir.getParent(), dir.getFileName().toString(), ".defunct");
+                Files.delete(tmpDir);
+                Files.move(dir, tmpDir);
+                SafeDeleting.removeDirectory(tmpDir);
+            }
         } catch (IOException e) {
             throw new UncheckedIOException("unable to delete lookups: " + dir, e);
         }

--- a/src/test/java/com/upserve/uppend/AppendOnlyStoreTest.java
+++ b/src/test/java/com/upserve/uppend/AppendOnlyStoreTest.java
@@ -23,7 +23,10 @@ public abstract class AppendOnlyStoreTest {
     }
 
     @After
-    public void cleanUp(){
+    public void cleanUp() {
+        if (store == null) {
+            return;
+        }
         try {
             store.close();
         } catch (Exception e){
@@ -56,6 +59,21 @@ public abstract class AppendOnlyStoreTest {
         store.append("partition", key, bytes);
         store.clear();
         assertEquals(0, store.read("partition", key).count());
+    }
+
+    @Test
+    public void testClearThenClose() throws Exception {
+        store.clear();
+        store.close();
+        store = null;
+    }
+
+    @Test
+    public void testWriteThenClearThenClose() throws Exception {
+        store.append("partition", "foo", "bar".getBytes());
+        store.clear();
+        store.close();
+        store = null;
     }
 
     @Test

--- a/src/test/java/com/upserve/uppend/AppendOnlyStoreTest.java
+++ b/src/test/java/com/upserve/uppend/AppendOnlyStoreTest.java
@@ -24,9 +24,6 @@ public abstract class AppendOnlyStoreTest {
 
     @After
     public void cleanUp() {
-        if (store == null) {
-            return;
-        }
         try {
             store.close();
         } catch (Exception e){
@@ -65,7 +62,6 @@ public abstract class AppendOnlyStoreTest {
     public void testClearThenClose() throws Exception {
         store.clear();
         store.close();
-        store = null;
     }
 
     @Test
@@ -73,7 +69,6 @@ public abstract class AppendOnlyStoreTest {
         store.append("partition", "foo", "bar".getBytes());
         store.clear();
         store.close();
-        store = null;
     }
 
     @Test

--- a/src/test/java/com/upserve/uppend/CounterStoreTest.java
+++ b/src/test/java/com/upserve/uppend/CounterStoreTest.java
@@ -54,6 +54,19 @@ public abstract class CounterStoreTest {
     }
 
     @Test
+    public void testClearThenClose() throws Exception {
+        store.clear();
+        store.close();
+    }
+
+    @Test
+    public void testWriteThenClearThenClose() throws Exception {
+        store.increment("partition", "foo");
+        store.clear();
+        store.close();
+    }
+
+    @Test
     public void testPartitions() throws Exception {
         store.increment("partition_one", "one", 1);
         store.increment("partition_two", "two", 2);


### PR DESCRIPTION
@dstuebe 

Fixed `unable to delete lookups` error when nothing had been writen before clearing, and avoided `unknown flushable` error in cases where `FileAppendOnlyStore.close()` is called twice. Extended same convention to `FileCounterStore` and added tests.