### PR TITLE
Remove lombok

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 
 plugins {
     id 'com.palantir.git-version' version '0.9.1'
-    id 'nebula.lint' version '6.7.0'
+    id 'nebula.lint' version '8.3.1'
 }
 
 import org.apache.tools.ant.filters.ExpandProperties

--- a/build.gradle
+++ b/build.gradle
@@ -55,9 +55,6 @@ dependencies {
     testCompile 'org.mockito:mockito-core:2.7.13'
 
     gradleLint.ignore {
-      // gradle-lint doesn't like lombok because it's annotation-only
-      compile 'org.projectlombok:lombok:1.16.12'
-
       // gradle-lint doesn't like log4j because it's not used directly
       compile 'org.apache.logging.log4j:log4j-core:2.8'
       compile 'org.apache.logging.log4j:log4j-slf4j-impl:2.8'

--- a/src/main/java/com/upserve/uppend/AutoFlusher.java
+++ b/src/main/java/com/upserve/uppend/AutoFlusher.java
@@ -1,14 +1,16 @@
 package com.upserve.uppend;
 
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
 
 import java.io.*;
+import java.lang.invoke.MethodHandles;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
-@Slf4j
 public class AutoFlusher {
+    private static final Logger log = org.slf4j.LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
     private static final int FLUSH_EXEC_POOL_NUM_THREADS = 20;
 
     private static final ConcurrentMap<Flushable, Integer> flushableDelays = new ConcurrentHashMap<>();

--- a/src/main/java/com/upserve/uppend/Blobs.java
+++ b/src/main/java/com/upserve/uppend/Blobs.java
@@ -1,16 +1,18 @@
 package com.upserve.uppend;
 
 import com.upserve.uppend.util.ThreadLocalByteBuffers;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
 
 import java.io.*;
+import java.lang.invoke.MethodHandles;
 import java.nio.ByteBuffer;
 import java.nio.channels.*;
 import java.nio.file.*;
 import java.util.concurrent.atomic.*;
 
-@Slf4j
 public class Blobs implements AutoCloseable, Flushable {
+    private static final Logger log = org.slf4j.LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
     private final Path file;
 
     private final FileChannel blobs;

--- a/src/main/java/com/upserve/uppend/BlockedLongs.java
+++ b/src/main/java/com/upserve/uppend/BlockedLongs.java
@@ -1,9 +1,10 @@
 package com.upserve.uppend;
 
 import com.upserve.uppend.util.ThreadLocalByteBuffers;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
 
 import java.io.*;
+import java.lang.invoke.MethodHandles;
 import java.nio.*;
 import java.nio.channels.FileChannel;
 import java.nio.file.*;
@@ -12,8 +13,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 import java.util.stream.LongStream;
 
-@Slf4j
 public class BlockedLongs implements AutoCloseable, Flushable {
+    private static final Logger log = org.slf4j.LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
     private static final int PAGE_SIZE = 4 * 1024 * 1024; // allocate 4 MB chunks
     private static final int MAX_PAGES = 1024 * 1024; // max 4 TB (~800 MB heap)
 

--- a/src/main/java/com/upserve/uppend/FileAppendOnlyStore.java
+++ b/src/main/java/com/upserve/uppend/FileAppendOnlyStore.java
@@ -1,15 +1,17 @@
 package com.upserve.uppend;
 
 import com.upserve.uppend.lookup.*;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
 
 import java.io.*;
+import java.lang.invoke.MethodHandles;
 import java.nio.file.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.*;
 
-@Slf4j
 public class FileAppendOnlyStore implements AppendOnlyStore {
+    private static final Logger log = org.slf4j.LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
     /**
      * DEFAULT_FLUSH_DELAY_SECONDS is the number of seconds to wait between
      * automatically flushing writes.

--- a/src/main/java/com/upserve/uppend/FileAppendOnlyStoreBuilder.java
+++ b/src/main/java/com/upserve/uppend/FileAppendOnlyStoreBuilder.java
@@ -1,12 +1,14 @@
 package com.upserve.uppend;
 
 import com.upserve.uppend.lookup.LongLookup;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
 
+import java.lang.invoke.MethodHandles;
 import java.nio.file.Path;
 
-@Slf4j
 public class FileAppendOnlyStoreBuilder implements AppendOnlyStoreBuilder<FileAppendOnlyStore> {
+    private static final Logger log = org.slf4j.LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
     private Path dir;
     private int longLookupHashSize = LongLookup.DEFAULT_HASH_SIZE;
     private int longLookupWriteCacheSize = LongLookup.DEFAULT_WRITE_CACHE_SIZE;

--- a/src/main/java/com/upserve/uppend/FileCounterStore.java
+++ b/src/main/java/com/upserve/uppend/FileCounterStore.java
@@ -1,15 +1,17 @@
 package com.upserve.uppend;
 
 import com.upserve.uppend.lookup.LongLookup;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
 
 import java.io.*;
+import java.lang.invoke.MethodHandles;
 import java.nio.file.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
 
-@Slf4j
 public class FileCounterStore implements CounterStore {
+    private static final Logger log = org.slf4j.LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
     /**
      * DEFAULT_FLUSH_DELAY_SECONDS is the number of seconds to wait between
      * automatically flushing writes.

--- a/src/main/java/com/upserve/uppend/FileCounterStoreBuilder.java
+++ b/src/main/java/com/upserve/uppend/FileCounterStoreBuilder.java
@@ -1,12 +1,14 @@
 package com.upserve.uppend;
 
 import com.upserve.uppend.lookup.LongLookup;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
 
+import java.lang.invoke.MethodHandles;
 import java.nio.file.Path;
 
-@Slf4j
 public class FileCounterStoreBuilder implements CounterStoreBuilder<FileCounterStore> {
+    private static final Logger log = org.slf4j.LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
     private Path dir;
     private int longLookupHashSize = LongLookup.DEFAULT_HASH_SIZE;
     private int longLookupWriteCacheSize = LongLookup.DEFAULT_WRITE_CACHE_SIZE;

--- a/src/main/java/com/upserve/uppend/cli/benchmark/Benchmark.java
+++ b/src/main/java/com/upserve/uppend/cli/benchmark/Benchmark.java
@@ -3,15 +3,17 @@ package com.upserve.uppend.cli.benchmark;
 import com.codahale.metrics.*;
 import com.codahale.metrics.Timer;
 import com.upserve.uppend.*;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
 
+import java.lang.invoke.MethodHandles;
 import java.nio.file.*;
 import java.util.*;
 
 import static com.upserve.uppend.metrics.AppendOnlyStoreWithMetrics.*;
 
-@Slf4j
 public class Benchmark {
+    private static final Logger log = org.slf4j.LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
     private BenchmarkWriter writer;
     private BenchmarkReader reader;
 

--- a/src/main/java/com/upserve/uppend/cli/benchmark/BenchmarkReader.java
+++ b/src/main/java/com/upserve/uppend/cli/benchmark/BenchmarkReader.java
@@ -1,12 +1,14 @@
 package com.upserve.uppend.cli.benchmark;
 
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
 
+import java.lang.invoke.MethodHandles;
 import java.util.function.Function;
 import java.util.stream.LongStream;
 
-@Slf4j
 public class BenchmarkReader implements Runnable {
+    private static final Logger log = org.slf4j.LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
     private final LongStream longStream;
     private final Function<Long, Integer> longFunction;
 

--- a/src/main/java/com/upserve/uppend/cli/benchmark/BenchmarkWriter.java
+++ b/src/main/java/com/upserve/uppend/cli/benchmark/BenchmarkWriter.java
@@ -1,12 +1,14 @@
 package com.upserve.uppend.cli.benchmark;
 
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
 
+import java.lang.invoke.MethodHandles;
 import java.util.function.Function;
 import java.util.stream.LongStream;
 
-@Slf4j
 public class BenchmarkWriter implements Runnable {
+    private static final Logger log = org.slf4j.LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
     private final LongStream longStream;
     private final Function<Long, Integer> longFunction;
 

--- a/src/main/java/com/upserve/uppend/lookup/LongLookup.java
+++ b/src/main/java/com/upserve/uppend/lookup/LongLookup.java
@@ -3,17 +3,19 @@ package com.upserve.uppend.lookup;
 import com.google.common.base.Charsets;
 import com.google.common.hash.*;
 import com.upserve.uppend.util.SafeDeleting;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
 
 import java.io.*;
+import java.lang.invoke.MethodHandles;
 import java.nio.file.*;
 import java.util.*;
 import java.util.concurrent.Phaser;
 import java.util.function.LongSupplier;
 import java.util.stream.Stream;
 
-@Slf4j
 public class LongLookup implements AutoCloseable, Flushable {
+    private static final Logger log = org.slf4j.LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
     /**
      * DEFAULT_HASH_SIZE is the number of hash elements per partition. Key
      * values hashed and modded by this number will be represented as paths

--- a/src/main/java/com/upserve/uppend/lookup/LookupData.java
+++ b/src/main/java/com/upserve/uppend/lookup/LookupData.java
@@ -2,9 +2,10 @@ package com.upserve.uppend.lookup;
 
 import com.upserve.uppend.util.*;
 import it.unimi.dsi.fastutil.objects.*;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
 
 import java.io.*;
+import java.lang.invoke.MethodHandles;
 import java.nio.ByteBuffer;
 import java.nio.channels.*;
 import java.nio.file.*;
@@ -13,8 +14,9 @@ import java.util.concurrent.atomic.*;
 import java.util.function.*;
 import java.util.stream.*;
 
-@Slf4j
 public class LookupData implements AutoCloseable, Flushable {
+    private static final Logger log = org.slf4j.LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
     private final AtomicBoolean isClosed;
 
     private final int keyLength;

--- a/src/main/java/com/upserve/uppend/lookup/LookupMetadata.java
+++ b/src/main/java/com/upserve/uppend/lookup/LookupMetadata.java
@@ -1,14 +1,16 @@
 package com.upserve.uppend.lookup;
 
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
 
 import java.io.*;
+import java.lang.invoke.MethodHandles;
 import java.nio.*;
 import java.nio.channels.*;
 import java.nio.file.*;
 
-@Slf4j
 public class LookupMetadata {
+    private static final Logger log = org.slf4j.LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
     private final int keyLength;
     private final int numKeys;
     private final LookupKey minKey;

--- a/src/test/java/com/upserve/uppend/LongLookupPerformanceTest.java
+++ b/src/test/java/com/upserve/uppend/LongLookupPerformanceTest.java
@@ -2,13 +2,15 @@ package com.upserve.uppend;
 
 import com.upserve.uppend.lookup.LongLookup;
 import com.upserve.uppend.util.SafeDeleting;
-import lombok.extern.slf4j.Slf4j;
 import org.junit.*;
+import org.slf4j.Logger;
 
+import java.lang.invoke.MethodHandles;
 import java.nio.file.*;
 
-@Slf4j
 public class LongLookupPerformanceTest {
+    private static final Logger log = org.slf4j.LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
     private static final int INITIAL_KEYS = 500_000;
 
     private Path lookupDir = Paths.get("build/test/tmp/lookup");

--- a/src/test/java/com/upserve/uppend/UppendTest.java
+++ b/src/test/java/com/upserve/uppend/UppendTest.java
@@ -1,14 +1,12 @@
 package com.upserve.uppend;
 
 import com.upserve.uppend.util.SafeDeleting;
-import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
 
 import java.nio.file.*;
 
 import static org.junit.Assert.*;
 
-@Slf4j
 public class UppendTest {
     @Test
     public void testVersion() {


### PR DESCRIPTION
Removing Lombok for two reasons:
1. It is being used solely for logging, which is simple enough to do without it
2. It was causing conflicts in other projects - the fewer dependencies, the better.
