### PR TITLE
Collect and stream partitions in parallel

### DIFF
--- a/src/main/java/com/upserve/uppend/lookup/LongLookup.java
+++ b/src/main/java/com/upserve/uppend/lookup/LongLookup.java
@@ -12,6 +12,7 @@ import java.nio.file.*;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.function.*;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class LongLookup implements AutoCloseable, Flushable {
@@ -199,7 +200,9 @@ public class LongLookup implements AutoCloseable, Flushable {
         return files
                 .filter(Files::isDirectory)
                 .filter(p -> !p.equals(dir))
-                .map(p -> p.getFileName().toString());
+                .map(p -> p.getFileName().toString())
+                .collect(Collectors.toList())
+                .parallelStream();
     }
 
     @Override


### PR DESCRIPTION
@bfulton Please review

When scanning over the contents of a FileAppendStore using the partitions and keys methods parallelization at the partition level is helpful. The underlying file system walk method however is a serialized stream as defined by the SplitIterator.

Since the number of partitions is expected to be low in Uppend (less than 1000) it is very reasonable to collect to a list and then create a parallel stream. This has been show to significantly improve performance in down stream applications. 