### PR TITLE
Enumerate keys rather than walking

### DIFF
--- a/src/main/java/com/upserve/uppend/lookup/LongLookup.java
+++ b/src/main/java/com/upserve/uppend/lookup/LongLookup.java
@@ -193,20 +193,15 @@ public class LongLookup implements AutoCloseable, Flushable {
     }
 
     public Stream<String> partitions() {
-        Stream<Path> files;
-        try {
-            if (!Files.exists(dir)) {
-                return Stream.empty();
-            }
-            files = Files.walk(dir, 1);
-        } catch (IOException e) {
-            throw new UncheckedIOException("could not walk dir " + dir, e);
+        File[] files = dir.toFile().listFiles();
+        if (files == null) {
+            return Stream.empty();
         }
 
-        return files
-                .filter(Files::isDirectory)
-                .filter(p -> !p.equals(dir))
-                .map(p -> p.getFileName().toString());
+        return Arrays
+                .stream(files)
+                .filter(File::isDirectory)
+                .map(File::getName);
     }
 
     @Override

--- a/src/main/java/com/upserve/uppend/lookup/LongLookup.java
+++ b/src/main/java/com/upserve/uppend/lookup/LongLookup.java
@@ -12,7 +12,7 @@ import java.nio.file.*;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.function.*;
-import java.util.stream.Stream;
+import java.util.stream.*;
 
 public class LongLookup implements AutoCloseable, Flushable {
     private static final Logger log = org.slf4j.LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
@@ -172,15 +172,22 @@ public class LongLookup implements AutoCloseable, Flushable {
             return Stream.empty();
         }
 
-        Stream<Path> files;
-        try {
-            files = Files.walk(partitionPath);
-        } catch (IOException e) {
-            throw new UncheckedIOException("could not walk partition " + partitionPath, e);
+        // Also see hashPath method in this class
+        Stream<String> paths = IntStream
+                .range(0, hashFinalByteMask + 1)
+                .mapToObj(i ->  String.format("%02x/data", i));
+
+        for (int i = 1; i < hashBytes; i++) {
+            paths = paths
+                    .flatMap(child -> IntStream
+                            .range(0, 256)
+                            .mapToObj(j -> String.format("%02x/%s", j, child))
+                    );
         }
-        return files
-                .filter(Files::isRegularFile)
-                .filter(p -> p.getFileName().toString().equals("data"))
+
+        return paths
+                .map(partitionPath::resolve)
+                .filter(Files::exists)
                 .flatMap(LookupData::keys)
                 .map(LookupKey::string);
     }
@@ -288,6 +295,7 @@ public class LongLookup implements AutoCloseable, Flushable {
         if (hashFunction == null) {
             hashPath = "00";
         } else {
+            // Also see keys method in this class
             byte[] hash = hashFunction.hashString(key.string(), Charsets.UTF_8).asBytes();
             switch (hashBytes) {
                 case 1:

--- a/src/test/java/com/upserve/uppend/lookup/LongLookupTest.java
+++ b/src/test/java/com/upserve/uppend/lookup/LongLookupTest.java
@@ -1,0 +1,48 @@
+package com.upserve.uppend.lookup;
+
+import com.upserve.uppend.util.SafeDeleting;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.*;
+
+import static org.junit.Assert.assertArrayEquals;
+
+public class LongLookupTest {
+
+    @Test
+    public void testKeysDepth1() throws Exception {
+        Path path = Paths.get("build/test/lookup-metadata-test/LongLookupTest");
+        SafeDeleting.removeDirectory(path);
+        LongLookup longLookup = new LongLookup(path, 1, LongLookup.DEFAULT_WRITE_CACHE_SIZE);
+        longLookup.put("partition", "b", 1);
+        longLookup.put("partition", "c", 1);
+        longLookup.put("partition", "a", 1);
+        assertArrayEquals(new String[] { "a", "b", "c" }, longLookup.keys("partition").sorted().toArray());
+        longLookup.close();
+    }
+
+    @Test
+    public void testKeysDepth2() throws Exception {
+        Path path = Paths.get("build/test/lookup-metadata-test/LongLookupTest");
+        SafeDeleting.removeDirectory(path);
+        LongLookup longLookup = new LongLookup(path, 257, LongLookup.DEFAULT_WRITE_CACHE_SIZE);
+        longLookup.put("partition", "b", 1);
+        longLookup.put("partition", "c", 1);
+        longLookup.put("partition", "a", 1);
+        assertArrayEquals(new String[] { "a", "b", "c" }, longLookup.keys("partition").sorted().toArray());
+        longLookup.close();
+    }
+
+    @Test
+    public void testKeysDepth3() throws Exception {
+        Path path = Paths.get("build/test/lookup-metadata-test/LongLookupTest");
+        SafeDeleting.removeDirectory(path);
+        LongLookup longLookup = new LongLookup(path, 65537, LongLookup.DEFAULT_WRITE_CACHE_SIZE);
+        longLookup.put("partition", "b", 1);
+        longLookup.put("partition", "c", 1);
+        longLookup.put("partition", "a", 1);
+        assertArrayEquals(new String[] { "a", "b", "c" }, longLookup.keys("partition").sorted().toArray());
+        longLookup.close();
+    }
+}

--- a/src/test/java/com/upserve/uppend/lookup/LongLookupTest.java
+++ b/src/test/java/com/upserve/uppend/lookup/LongLookupTest.java
@@ -45,4 +45,16 @@ public class LongLookupTest {
         assertArrayEquals(new String[] { "a", "b", "c" }, longLookup.keys("partition").sorted().toArray());
         longLookup.close();
     }
+
+    @Test
+    public void testPartitions() throws Exception {
+        Path path = Paths.get("build/test/lookup-metadata-test/LongLookupTest");
+        SafeDeleting.removeDirectory(path);
+        LongLookup longLookup = new LongLookup(path);
+        longLookup.put("b", "b", 1);
+        longLookup.put("c", "c", 1);
+        longLookup.put("a", "a", 1);
+        assertArrayEquals(new String[] { "a", "b", "c" }, longLookup.partitions().sorted().toArray());
+        longLookup.close();
+    }
 }


### PR DESCRIPTION
I ran into a problem with files unrelated to the `keys` operation disappearing during the walk. Since we only care about certain files, and know which files those are, this just enumerates those files.