### PR TITLE
hash size not working properly

### DIFF
--- a/src/test/java/com/upserve/uppend/lookup/LongLookupTest.java
+++ b/src/test/java/com/upserve/uppend/lookup/LongLookupTest.java
@@ -7,6 +7,8 @@ import org.junit.*;
 import java.io.IOException;
 import java.nio.file.*;
 import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.junit.Assert.*;
@@ -52,13 +54,12 @@ public class LongLookupTest {
             Path hashPath = path.resolve(String.format("byte-boundary-%d", hashSize));
             SafeDeleting.removeDirectory(hashPath);
             try (LongLookup longLookup = new LongLookup(hashPath, hashSize, 1)) {
-                assertEquals(hashSize, IntStream
-                        .range(0, hashSize)
+                Map<String, Long> hashMap = IntStream
+                        .range(0, 1_048_576)
                         .mapToObj(HashCode::fromInt)
                         .map(longLookup::hashPath)
-                        .distinct()
-                        .count()
-                );
+                        .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
+                assertEquals(hashSize, hashMap.size());
             }
         }
     }

--- a/src/test/test.iml
+++ b/src/test/test.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/java" isTestSource="true" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="module" module-name="main" />
+  </component>
+</module>


### PR DESCRIPTION
@bfulton I think this is still not working properly. 
If the range of hash values is larger than the hash size the test fails.

I think the hash distribution strategy is broken for values of hash size other than powers of two as I suggested in the previous #62 because you would not expect an even distribution using this approach.