### PR TITLE
Scan Size and Purge

### DIFF
--- a/src/main/java/com/upserve/uppend/AppendOnlyObjectStore.java
+++ b/src/main/java/com/upserve/uppend/AppendOnlyObjectStore.java
@@ -1,6 +1,9 @@
 package com.upserve.uppend;
 
+import com.google.common.collect.Maps;
+
 import java.io.*;
+import java.util.Map;
 import java.util.function.*;
 import java.util.stream.Stream;
 
@@ -153,5 +156,30 @@ public class AppendOnlyObjectStore<T> implements AutoCloseable, Flushable {
     @Override
     public void flush() throws IOException {
         store.flush();
+    }
+
+    /**
+     * Scan all the keys and values in a partition return a stream of entries
+     * @param partition the name of the partition
+     * @return a Stream of Entries containing the key and a stream of values
+     */
+    public Stream<Map.Entry<String, Stream<T>>> scan(String partition){
+        return store.scan(partition).map(entry ->
+                Maps.immutableEntry(entry.getKey(), entry.getValue().map(deserializer)));
+    }
+
+    /**
+     * The estimated size of the append store including unflushed keys
+     * @return the size
+     */
+    public Long size(){
+        return store.size();
+    }
+
+    /**
+     * Used the purge the write cache and save heap space when it is not currently needed for a particular store
+     */
+    public void purgeWriteCache(){
+        store.purgeWriteCache();
     }
 }

--- a/src/main/java/com/upserve/uppend/AppendOnlyStore.java
+++ b/src/main/java/com/upserve/uppend/AppendOnlyStore.java
@@ -33,7 +33,6 @@ public interface AppendOnlyStore extends ReadOnlyAppendOnlyStore, Flushable {
      */
     Stream<byte[]> readSequentialFlushed(String partition, String key);
 
-
     /**
      * Read the last byte array that was stored under a given partition and
      * key, skipping the write cache of this store so that unflushed data is not
@@ -62,6 +61,11 @@ public interface AppendOnlyStore extends ReadOnlyAppendOnlyStore, Flushable {
      */
     @Override
     void flush();
+
+    /**
+     * Purge the write cache
+     */
+    void purgeWriteCache();
 
     /**
      * Remove all keys and values from the store.

--- a/src/main/java/com/upserve/uppend/ReadOnlyAppendOnlyStore.java
+++ b/src/main/java/com/upserve/uppend/ReadOnlyAppendOnlyStore.java
@@ -1,5 +1,6 @@
 package com.upserve.uppend;
 
+import java.util.Map;
 import java.util.stream.Stream;
 
 /**
@@ -28,7 +29,6 @@ public interface ReadOnlyAppendOnlyStore extends AutoCloseable {
      */
     Stream<byte[]> readSequential(String partition, String key);
 
-
     /**
      * Read the last byte array that was stored under a given partition and key
      *
@@ -54,4 +54,18 @@ public interface ReadOnlyAppendOnlyStore extends AutoCloseable {
      * @return a stream of string partition
      */
     Stream<String> partitions();
+
+    /**
+     * Scan the given partition returning a stream of the contents including the key
+     * @param partition the partition to scan
+     * @return a stream of entries containing the key and the bytes
+     */
+    Stream<Map.Entry<String, Stream<byte[]>>> scan(String partition);
+
+    /**
+     * The approximate number of keys in the data store. Keys that have been written but not yet flushed are counted.
+     *
+     * @return the number of keys
+     */
+    long size();
 }

--- a/src/test/java/com/upserve/uppend/AppendOnlyStoreTest.java
+++ b/src/test/java/com/upserve/uppend/AppendOnlyStoreTest.java
@@ -75,6 +75,21 @@ public class AppendOnlyStoreTest {
     }
 
     @Test
+    public void size() {
+        assertEquals(0L, store.size());
+        store.append("partition0", "foo1", "bar".getBytes());
+        assertEquals(1L, store.size());
+        store.append("partition0", "foo1", "bar".getBytes());
+        assertEquals(1L, store.size());
+        store.append("partition1", "foo1", "bar".getBytes());
+        assertEquals(2L, store.size());
+        store.append("partition1", "foo1", "bar".getBytes());
+        assertEquals(2L, store.size());
+        store.append("partition1", "foo2", "bar".getBytes());
+        assertEquals(3L, store.size());
+    }
+
+    @Test
     public void fillTheCache() {
         int keys = LongLookup.DEFAULT_WRITE_CACHE_SIZE * 2;
 

--- a/src/test/java/com/upserve/uppend/lookup/LongLookupTest.java
+++ b/src/test/java/com/upserve/uppend/lookup/LongLookupTest.java
@@ -1,5 +1,6 @@
 package com.upserve.uppend.lookup;
 
+import com.google.common.collect.*;
 import com.google.common.hash.HashCode;
 import com.upserve.uppend.util.SafeDeleting;
 import org.junit.*;
@@ -7,7 +8,7 @@ import org.junit.*;
 import java.io.IOException;
 import java.nio.file.*;
 import java.util.*;
-import java.util.stream.IntStream;
+import java.util.stream.*;
 
 import static org.junit.Assert.*;
 
@@ -115,9 +116,51 @@ public class LongLookupTest {
         longLookup.close();
     }
 
+    @Test
+    public void testPurgeCache() {
+        LongLookup longLookup = new LongLookup(path);
+        longLookup.put("a", "b", 1);
+        assertEquals(1, longLookup.cacheSize());
+        assertEquals(1L, longLookup.get("a","b"));
+        longLookup.close();
+        assertEquals(0, longLookup.cacheSize());
+        assertEquals(1L, longLookup.get("a","b"));
+        longLookup.put("c", "d", 2);
+        assertEquals(1, longLookup.cacheSize());
+        assertEquals(1L, longLookup.get("a","b"));
+
+        longLookup.close();
+    }
 
     @Test
-    public void testScan() throws Exception {
+    public void testScanStream() throws Exception {
+        LongLookup longLookup = new LongLookup(path);
+        longLookup.put("a", "a1", 1);
+        longLookup.put("a", "a2", 2);
+        longLookup.put("b", "b1", 1);
+        longLookup.put("b", "b2", 2);
+        longLookup.close();
+
+        List<Map.Entry<String, Long>> results;
+        List<Map.Entry<String, Long>> expected;
+
+        longLookup = new LongLookup(path);
+        results = longLookup.scan("a").collect(Collectors.toList());
+        expected =  Arrays.asList(Maps.immutableEntry("a1",1L), Maps.immutableEntry("a2", 2L));
+
+        assertEquals(expected, results);
+
+        results = longLookup.scan("b").collect(Collectors.toList());
+        expected =  Arrays.asList(Maps.immutableEntry("b1",1L), Maps.immutableEntry("b2", 2L));
+        assertEquals(expected, results);
+
+        assertEquals(0, longLookup.scan("c").count());
+
+        longLookup.close();
+    }
+
+    @Test
+    public void testScanBiFunction() throws Exception {
         LongLookup longLookup = new LongLookup(path);
         longLookup.put("a", "a1", 1);
         longLookup.put("a", "a2", 2);


### PR DESCRIPTION
@bfulton Please review
New features
* Scan a partition returning a stream of Entries. Each entry contains a Key and a Stream of Values
* Size returns an estimated size (number of keys) of the append store
* Purge allows the application to purge the write cache and save heap space when the cache is not needed by the application

Issues:
* The metrics are suspect for the scan operation. The time to return the stream object is not the time to read the stream. Adding metric to the actual read operation would be much more intrusive. 
* For the scan I was also unable to peek the stream inside the Entry. It caused a stream already closed error.
* I would like to refactor the Iterators and Stream of iterators methods in LookupData but I need help withe the consolidation.
