### PR TITLE
Add the bufferedAppendOnlyStore for writing to random keys

### DIFF
--- a/src/main/java/com/upserve/uppend/AppendOnlyStoreBuilder.java
+++ b/src/main/java/com/upserve/uppend/AppendOnlyStoreBuilder.java
@@ -15,7 +15,7 @@ public class AppendOnlyStoreBuilder {
     private int flushDelaySeconds = FileAppendOnlyStore.DEFAULT_FLUSH_DELAY_SECONDS;
     private MetricRegistry metrics;
 
-    private int maxBufferSize = 0;
+    private int suggestedBufferSize = 0;
     private ExecutorService executorService = null;
 
     public AppendOnlyStoreBuilder withDir(Path dir) {
@@ -28,13 +28,13 @@ public class AppendOnlyStoreBuilder {
         return this;
     }
 
-    public AppendOnlyStoreBuilder withBufferedAppend(int maxBufferSize){
-        this.maxBufferSize = maxBufferSize;
+    public AppendOnlyStoreBuilder withBufferedAppend(int suggestedBufferSize){
+        this.suggestedBufferSize = suggestedBufferSize;
         return this;
     }
 
     public AppendOnlyStoreBuilder withBufferedAppend(int maxBufferSize, ExecutorService executorService){
-        this.maxBufferSize = maxBufferSize;
+        this.suggestedBufferSize = maxBufferSize;
         this.executorService = executorService;
         return this;
     }
@@ -56,9 +56,9 @@ public class AppendOnlyStoreBuilder {
 
     public AppendOnlyStore build() {
         AppendOnlyStore store;
-        if (maxBufferSize > 0) {
+        if (suggestedBufferSize > 0) {
             // Add log message about ignored parameters
-            store = new BufferedAppendOnlyStore(dir, true, longLookupHashSize, maxBufferSize, Optional.ofNullable(executorService));
+            store = new BufferedAppendOnlyStore(dir, true, longLookupHashSize, suggestedBufferSize, Optional.ofNullable(executorService));
         } else {
             store = new FileAppendOnlyStore(dir, flushDelaySeconds, true, longLookupHashSize, longLookupWriteCacheSize);
         }
@@ -81,7 +81,7 @@ public class AppendOnlyStoreBuilder {
                 ", longLookupWriteCacheSize=" + longLookupWriteCacheSize +
                 ", flushDelaySeconds=" + flushDelaySeconds +
                 ", metrics=" + metrics +
-                ", bufferedAppend=" + maxBufferSize +
+                ", bufferedAppendSize=" + suggestedBufferSize +
                 '}';
     }
 }

--- a/src/main/java/com/upserve/uppend/BufferedAppendOnlyStore.java
+++ b/src/main/java/com/upserve/uppend/BufferedAppendOnlyStore.java
@@ -47,7 +47,8 @@ public class BufferedAppendOnlyStore extends FileAppendOnlyStore {
 
     @Override
     public void clear(){
-        lookupAppendBuffer.flush();
+        lookupAppendBuffer.clearLock();
         super.clear();
+        lookupAppendBuffer.unlock();
     }
 }

--- a/src/main/java/com/upserve/uppend/BufferedAppendOnlyStore.java
+++ b/src/main/java/com/upserve/uppend/BufferedAppendOnlyStore.java
@@ -12,15 +12,18 @@ import java.util.concurrent.ExecutorService;
  * The Buffered Append Only Store is optimized for random writes to the partition and key with fixed memory use at the
  * expense of durability and latency. No guarantee is made about when an append operation will be durably persisted or available
  * to read. The application must successfully call flush or close to persist the appended values.
+ *
+ * By default the provided buffer size is a suggestion. The buffer is actually flushed based on the number of entries
+ * with entropy in a range equal the the suggested size divided by 5.
  */
 public class BufferedAppendOnlyStore extends FileAppendOnlyStore {
     private static final Logger log = org.slf4j.LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     private final LookupAppendBuffer lookupAppendBuffer;
 
-    BufferedAppendOnlyStore(Path dir, boolean doLock, int longLookupHashSize, int maxBufferSize, Optional<ExecutorService> executorService) {
+    BufferedAppendOnlyStore(Path dir, boolean doLock, int longLookupHashSize, int bufferSize, Optional<ExecutorService> executorService) {
         super(dir, 0, doLock, longLookupHashSize, 0);
-        lookupAppendBuffer = new LookupAppendBuffer(lookups, blocks, maxBufferSize, executorService);
+        lookupAppendBuffer = new LookupAppendBuffer(lookups, blocks, bufferSize, bufferSize/5, executorService);
     }
 
     @Override

--- a/src/main/java/com/upserve/uppend/FileAppendOnlyStore.java
+++ b/src/main/java/com/upserve/uppend/FileAppendOnlyStore.java
@@ -12,11 +12,11 @@ public class FileAppendOnlyStore extends FileStore implements AppendOnlyStore {
 
     private static final int NUM_BLOBS_PER_BLOCK = 127;
 
-    private final LongLookup lookups;
-    private final BlockedLongs blocks;
-    private final Blobs blobs;
+    protected final LongLookup lookups;
+    protected final BlockedLongs blocks;
+    protected final Blobs blobs;
 
-    FileAppendOnlyStore(Path dir, int flushDelaySeconds, boolean doLock, int longLookupHashSize, int longLookupWriteCacheSize) {
+    protected FileAppendOnlyStore(Path dir, int flushDelaySeconds, boolean doLock, int longLookupHashSize, int longLookupWriteCacheSize) {
         super(dir, flushDelaySeconds, doLock);
 
         lookups = new LongLookup(

--- a/src/main/java/com/upserve/uppend/cli/CommandBenchmark.java
+++ b/src/main/java/com/upserve/uppend/cli/CommandBenchmark.java
@@ -33,6 +33,9 @@ public class CommandBenchmark implements Callable<Void> {
     @Option(names = {"-n", "--count"}, description = "Count")
     int count = 1_000_000;
 
+    @Option(names = {"-b", "--buffered"}, description = "Use Buffered AppendStore")
+    int buffered = 0;
+
     @Option(names = {"-h", "--hash-size"}, description = "Hash size")
     int hashSize = LongLookup.DEFAULT_HASH_SIZE;
 
@@ -48,7 +51,7 @@ public class CommandBenchmark implements Callable<Void> {
 
     @Override
     public Void call() throws Exception {
-        Benchmark benchmark = new Benchmark(mode, path, maxPartitions, maxKeys, count, hashSize, cacheSize, flushDelay);
+        Benchmark benchmark = new Benchmark(mode, path, maxPartitions, maxKeys, count, hashSize, cacheSize, flushDelay, buffered);
         benchmark.run();
         return null;
     }

--- a/src/main/java/com/upserve/uppend/cli/CommandBenchmark.java
+++ b/src/main/java/com/upserve/uppend/cli/CommandBenchmark.java
@@ -33,7 +33,7 @@ public class CommandBenchmark implements Callable<Void> {
     @Option(names = {"-n", "--count"}, description = "Count")
     int count = 1_000_000;
 
-    @Option(names = {"-b", "--buffered"}, description = "Use Buffered AppendStore")
+    @Option(names = {"-b", "--buffered"}, description = "Use BufferedAppendOnlyStore with this size")
     int buffered = 0;
 
     @Option(names = {"-h", "--hash-size"}, description = "Hash size")

--- a/src/main/java/com/upserve/uppend/cli/benchmark/Benchmark.java
+++ b/src/main/java/com/upserve/uppend/cli/benchmark/Benchmark.java
@@ -30,7 +30,7 @@ public class Benchmark {
 
     private volatile boolean isDone = false;
 
-    public Benchmark(BenchmarkMode mode, Path path, int maxPartitions, int maxKeys, int count, int hashSize, int cachesize, int flushDelaySeconds) {
+    public Benchmark(BenchmarkMode mode, Path path, int maxPartitions, int maxKeys, int count, int hashSize, int cachesize, int flushDelaySeconds, int buffered) {
 
         this.count = count;
         this.maxPartitions = maxPartitions; // max ~ 2000
@@ -46,6 +46,7 @@ public class Benchmark {
                 .withLongLookupHashSize(hashSize)
                 .withLongLookupWriteCacheSize(cachesize)
                 .withFlushDelaySeconds(flushDelaySeconds)
+                .withBufferedAppend(buffered)
                 .withMetrics(metrics)
                 .build();
 

--- a/src/main/java/com/upserve/uppend/lookup/LongLookup.java
+++ b/src/main/java/com/upserve/uppend/lookup/LongLookup.java
@@ -298,7 +298,7 @@ public class LongLookup implements AutoCloseable, Flushable {
         }
     }
 
-    private Path hashPath(String partition, LookupKey key) {
+    public Path hashPath(String partition, LookupKey key) {
         String hashPath = hashFunction == null ? "00" : hashPath(hashFunction.hashString(key.string(), Charsets.UTF_8));
         return dir.resolve(partition).resolve(hashPath);
     }

--- a/src/main/java/com/upserve/uppend/lookup/LookupAppendBuffer.java
+++ b/src/main/java/com/upserve/uppend/lookup/LookupAppendBuffer.java
@@ -188,4 +188,13 @@ public class LookupAppendBuffer {
             tasks.add(threadPool.submit(() -> flushEntry(path, entryList)));
         }
     }
+
+    public void clearLock() {
+        closed.set(true);
+        flush();
+    }
+
+    public void unlock() {
+        closed.set(false);
+    }
 }

--- a/src/main/java/com/upserve/uppend/lookup/LookupAppendBuffer.java
+++ b/src/main/java/com/upserve/uppend/lookup/LookupAppendBuffer.java
@@ -1,0 +1,174 @@
+package com.upserve.uppend.lookup;
+
+import com.google.common.collect.*;
+import com.upserve.uppend.BlockedLongs;
+import org.slf4j.Logger;
+
+import java.io.*;
+import java.lang.invoke.MethodHandles;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.*;
+
+/**
+ * A buffered Lookup Writer for memory efficient writes to random hashPaths in the append only store.
+ * This buffer maintains a high throughput with fixed memory use by sacrificing guaranteed durability. The application
+ * must successfully flush the append store before an append is guaranteed to be written.
+ */
+public class LookupAppendBuffer {
+    private static final Logger log = org.slf4j.LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+    private static final int MIN_BUFFER_SIZE = 20;
+
+    private final int maxSize;
+    private final LongLookup longLookup;
+    private final BlockedLongs blockedLongs;
+    private final ConcurrentHashMap<Path, List<Map.Entry<LookupKey, Long>>> appendBuffer;
+    private final ExecutorService threadPool;
+    private final boolean myThreadPool;
+
+    private final ConcurrentLinkedQueue<Future> tasks = Queues.newConcurrentLinkedQueue();
+    AtomicBoolean closed = new AtomicBoolean(false);
+
+    public LookupAppendBuffer(LongLookup longLookup, BlockedLongs blockedLongs, int bufferMax, Optional<ExecutorService> threadPool) {
+        if (bufferMax < MIN_BUFFER_SIZE) throw new IllegalArgumentException(String.format("Invalid buffer size %s is less than %s", bufferMax, MIN_BUFFER_SIZE));
+        this.longLookup = longLookup;
+        this.blockedLongs = blockedLongs;
+        this.appendBuffer = new ConcurrentHashMap<>();
+        this.maxSize = bufferMax;
+        this.threadPool = threadPool.orElse(Executors.newFixedThreadPool(4));
+        this.myThreadPool = ! threadPool.isPresent();
+
+        this.threadPool.submit(() -> cleanupTask());
+    }
+
+
+    /**
+     * Add a blob position for a partition and key the the buffered Map. If the number of entries for that hashPath
+     * exceeds the bufferSize then submit a task to flush that entry.
+     *
+     * @param partition the append store partition
+     * @param key the append store key
+     * @param blobPos the position of the bytes in the blob file
+     */
+    public void bufferedAppend(String partition, String key, long blobPos) {
+        LookupKey lookupKey = new LookupKey(key);
+
+        // ConcurrentHashMap guarantees atomic, blocking exactly once execution of the compute method.
+        appendBuffer.compute(longLookup.hashPath(partition, lookupKey), (Path pathKey, List<Map.Entry<LookupKey, Long>> entryList) -> {
+            if (entryList == null) {
+                entryList = new ArrayList<>(maxSize + 1);
+            }
+
+            if (closed.get()) throw new RuntimeException("Closed for business");
+
+            entryList.add(Maps.immutableEntry(lookupKey, blobPos));
+
+            if (entryList.size() >= maxSize) {
+                List<Map.Entry<LookupKey, Long>> finalEntryList = new ArrayList<>(entryList);
+                entryList.clear();
+                tasks.add(threadPool.submit(() -> flushEntry(pathKey, finalEntryList)));
+            }
+            return entryList;
+        });
+    }
+
+    /**
+     * Returns the size of the buffer Map. Note that entries are never removed so the map will grow to the size of
+     * the hash space and never shrink. This is not the number of appends currently buffered.
+     *
+     * @return the number of entries in the buffer Map.
+     */
+    public int bufferCount(){
+        return appendBuffer.size();
+    }
+
+    protected ConcurrentLinkedQueue<Future> getTasks(){
+        return tasks;
+    }
+
+    private void cleanupTask() {
+        AtomicLong counter = new AtomicLong();
+        Iterator<Future> iter = tasks.iterator();
+        iter.forEachRemaining(future -> {
+            if (future.isDone()) {
+                try {
+                    future.get();
+                } catch (InterruptedException e) {
+                    log.error("Buffered Append task interrupted", e);
+                } catch (ExecutionException e) {
+                    log.error("Buffered Append exception", e);
+                } finally {
+                    iter.remove();
+                    counter.addAndGet(1);
+                }
+            }
+        });
+
+        log.debug("Reaped {} successful buffer flush tasks", counter.get());
+
+        try {
+            Thread.sleep(500);
+            if (! closed.get()) threadPool.submit(this::cleanupTask);
+        } catch (InterruptedException e) {
+            log.error("cleanup sleep interrupted", e);
+        }
+    }
+
+
+    public void flush() {
+        appendBuffer.forEach((path, entryList) -> {
+            List<Map.Entry<LookupKey, Long>> finalEntryList = new ArrayList<>(entryList);
+            entryList.clear();
+            tasks.add(threadPool.submit(() -> flushEntry(path, finalEntryList)));
+        });
+
+        // Ensure that all the tasks currently in the queue finish before returning
+        tasks.iterator().forEachRemaining(f -> {
+            try {
+                f.get(500, TimeUnit.MILLISECONDS);
+            } catch (InterruptedException e) {
+                log.error("Buffered Append task interrupted", e);
+            } catch (ExecutionException e) {
+                log.error("Buffered Append exception", e);
+            } catch (TimeoutException e) {
+                log.error("Buffered Append task timed out in flush", e);
+            }
+        });
+    }
+
+    public void close() {
+        if (closed.getAndSet(true)) return;
+
+        flush();
+        if (myThreadPool) {
+            threadPool.shutdown();
+            try {
+                boolean result = threadPool.awaitTermination(4000, TimeUnit.MILLISECONDS);
+                if (result) {
+                    log.debug("flushed the buffer and closed the thread pool!");
+                } else {
+                    log.error("Close timed out waiting for tasks to finish");
+                }
+            } catch (InterruptedException e) {
+                log.error("close interrupted!", e);
+            }
+        }
+    }
+
+    private void flushEntry(Path path, List<Map.Entry<LookupKey, Long>> entryList) {
+        LookupData lookupData = new LookupData(path.resolve("data"), path.resolve("meta"));
+
+        entryList.forEach(entry -> {
+            long blockPos = lookupData.putIfNotExists(entry.getKey(), blockedLongs::allocate);
+            blockedLongs.append(blockPos, entry.getValue());
+        });
+
+        try {
+            lookupData.close();
+        } catch (IOException e) {
+            log.error("Could not close lookup buffer for {}", path);
+        }
+    }
+}

--- a/src/test/java/com/upserve/uppend/lookup/LookupAppendBufferTest.java
+++ b/src/test/java/com/upserve/uppend/lookup/LookupAppendBufferTest.java
@@ -1,0 +1,106 @@
+package com.upserve.uppend.lookup;
+
+import com.upserve.uppend.*;
+import com.upserve.uppend.util.SafeDeleting;
+import org.junit.*;
+
+import java.io.IOException;
+import java.nio.file.*;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.IntStream;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class LookupAppendBufferTest {
+    private final Path path = Paths.get("build/test/long-lookup-test");
+
+    private LookupAppendBuffer instance;
+    private LongLookup longLookup;
+    private BlockedLongs blockedLongs;
+
+    @Before
+    public void init() throws IOException {
+        SafeDeleting.removeDirectory(path);
+
+        longLookup = new LongLookup(path);
+        blockedLongs = new BlockedLongs(path.resolve("blocks"), 128);
+
+        instance = new LookupAppendBuffer(longLookup, blockedLongs, 24, Optional.empty());
+    }
+
+    @After
+    public void cleanup() throws Exception {
+        instance.close();
+        longLookup.close();
+        blockedLongs.close();
+        SafeDeleting.removeDirectory(path);
+    }
+
+    @Test
+    public void testAppend() throws InterruptedException, ExecutionException {
+        instance.bufferedAppend("partition1", "key", 15);
+        assertEquals(1, instance.bufferCount());
+
+        instance.bufferedAppend("partition1", "key", 72);
+        assertEquals(1, instance.bufferCount());
+
+        instance.bufferedAppend("partition2", "key", 16);
+        assertEquals(2, instance.bufferCount());
+
+        instance.flush();
+
+        long lookup;
+        lookup = longLookup.get("partition1","key");
+        assertArrayEquals(new long[]{15, 72}, blockedLongs.values(lookup).toArray());
+
+        instance.bufferedAppend("partition2", "key", 29);
+        assertEquals(2, instance.bufferCount());
+
+        // New data is not yet written
+        lookup = longLookup.get("partition2","key");
+        assertArrayEquals(new long[]{16}, blockedLongs.values(lookup).toArray());
+    }
+
+    @Test
+    public void fixedSizeFlush() throws ExecutionException, InterruptedException {
+        IntStream.range(0, 24).forEach(val -> instance.bufferedAppend("partition3", "key", val));
+
+        instance.getTasks().peek().get();
+
+        long lookup = longLookup.get("partition3","key");
+        assertEquals(24, blockedLongs.values(lookup).count());
+    }
+
+    @Test
+    public void testClose(){
+        instance.bufferedAppend("partition1", "key", 15);
+        assertEquals(1, instance.bufferCount());
+
+        instance.bufferedAppend("partition1", "key", 72);
+        assertEquals(1, instance.bufferCount());
+
+        instance.bufferedAppend("partition2", "key", 16);
+        assertEquals(2, instance.bufferCount());
+
+        instance.close();
+
+        long lookup;
+        lookup = longLookup.get("partition1","key");
+        assertArrayEquals(new long[]{15, 72}, blockedLongs.values(lookup).toArray());
+
+        lookup = longLookup.get("partition2","key");
+        assertArrayEquals(new long[]{16}, blockedLongs.values(lookup).toArray());
+
+
+        Exception expected = null;
+        try {
+            instance.bufferedAppend("partition2", "key", 16);
+        } catch (RuntimeException e) {
+            expected = e;
+        }
+        assertNotNull("Should have failed to write to a closed buffered appender",expected);
+    }
+}

--- a/src/test/java/com/upserve/uppend/lookup/LookupAppendBufferTest.java
+++ b/src/test/java/com/upserve/uppend/lookup/LookupAppendBufferTest.java
@@ -111,4 +111,40 @@ public class LookupAppendBufferTest {
         }
         assertNotNull("Should have failed to write to a closed buffered appender",expected);
     }
+
+
+    @Test
+    public void testClear(){
+        instance.bufferedAppend("partition1", "key", 15);
+        assertEquals(1, instance.bufferCount());
+
+        instance.flush();
+        long lookup;
+        lookup = longLookup.get("partition1","key");
+        assertArrayEquals(new long[]{15}, blockedLongs.values(lookup).toArray());
+
+        instance.clearLock();
+        Exception expected = null;
+        try {
+            instance.bufferedAppend("partition1", "key", 15);
+        }catch (RuntimeException e) {
+            expected = e;
+        }
+        assertNotNull("Should have failed to write to a closed buffered appender", expected);
+
+        blockedLongs.clear();
+        longLookup.clear();
+        instance.unlock();
+
+        assertEquals(-1, longLookup.get("partition1","key"));
+
+        instance.bufferedAppend("partition1", "key", 16);
+        assertEquals(1, instance.bufferCount());
+
+        instance.flush();
+        lookup = longLookup.get("partition1","key");
+        assertArrayEquals(new long[]{16}, blockedLongs.values(lookup).toArray());
+
+
+    }
 }

--- a/src/test/java/com/upserve/uppend/lookup/LookupAppendBufferTest.java
+++ b/src/test/java/com/upserve/uppend/lookup/LookupAppendBufferTest.java
@@ -26,7 +26,7 @@ public class LookupAppendBufferTest {
         longLookup = new LongLookup(path);
         blockedLongs = new BlockedLongs(path.resolve("blocks"), 128);
 
-        instance = new LookupAppendBuffer(longLookup, blockedLongs, 24, Optional.empty());
+        instance = new LookupAppendBuffer(longLookup, blockedLongs, 24, 0, Optional.empty());
     }
 
     @After


### PR DESCRIPTION
@bfulton Please review

Adds a BufferedAppendOnlyStore which uses a fixed amount of heap while providing much higher throughput (appends / second) for random keys than the FileAppendOnlyStore. The trade off is that the appended values are not guaranteed to be durably written till the application explicitly flushes the append store.

Here are [Benchmark Stats](https://gist.github.com/dstuebe/98b48de77d546658ca59af3dfc28466e) comparing write performance and memory use for the BufferedAppendOnlyStore vs the FileAppendOnlyStore with all partition in memory and 2 of 32 in memory (HOT).