### PR TITLE
Concurrent lookups

### DIFF
--- a/src/main/java/com/upserve/uppend/cli/benchmark/Benchmark.java
+++ b/src/main/java/com/upserve/uppend/cli/benchmark/Benchmark.java
@@ -101,7 +101,7 @@ public class Benchmark {
     }
 
     public static byte[] bytes(long integer) {
-        int length =(int) (integer % 65536);
+        int length =(int) (integer % 1024);
         byte[] bytes = new byte[length];
         Arrays.fill(bytes, (byte) 0);
         return bytes;

--- a/src/main/java/com/upserve/uppend/lookup/ConcurrentCache.java
+++ b/src/main/java/com/upserve/uppend/lookup/ConcurrentCache.java
@@ -1,0 +1,128 @@
+package com.upserve.uppend.lookup;
+
+import com.google.common.collect.Maps;
+import com.upserve.uppend.AutoFlusher;
+import org.slf4j.Logger;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.*;
+import java.util.function.*;
+
+public class ConcurrentCache {
+    private static final Logger log = org.slf4j.LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+    private final ConcurrentHashMap<Path, CacheEntry> cache;
+    private final int cacheSize;
+
+    private final AtomicLong expired = new AtomicLong();
+    private final AtomicBoolean sizeExceeded = new AtomicBoolean();
+
+    public ConcurrentCache(int cacheSize, float loadFactor){
+        this.cache = new ConcurrentHashMap<>(cacheSize, loadFactor);
+        this.cacheSize = cacheSize;
+    }
+
+    private static class CacheEntry{
+        protected final AtomicLong lastTouched;
+        protected final AtomicBoolean tombStone;
+        protected final AtomicReference<LookupData> lookupData;
+
+        protected CacheEntry(AtomicLong lastTouched, AtomicBoolean tombStone, LookupData lookupData){
+            this.lastTouched = lastTouched;
+            this.lookupData = new AtomicReference<>(lookupData);
+            this.tombStone = tombStone;
+        }
+
+        protected CacheEntry(LookupData lookupData){
+            this(new AtomicLong(System.nanoTime()), new AtomicBoolean(false), lookupData);
+        }
+
+    }
+
+    public <T> T compute(Path path, Function<LookupData, T> function){
+        AtomicReference<T> result = new AtomicReference<>(null);
+        cache.compute(path, (Path keyPath, CacheEntry cacheEntry) -> {
+            if (cacheEntry == null){
+                log.trace("cache loading {}", keyPath);
+                LookupData lookupData = new LookupData(keyPath.resolve("data"), keyPath.resolve("meta"));
+                result.set(function.apply(lookupData));
+                return new CacheEntry(lookupData);
+            } else {
+                cacheEntry.lastTouched.set(System.nanoTime());
+                result.set(function.apply(cacheEntry.lookupData.get()));
+                return cacheEntry;
+            }
+        });
+
+        sizeExceeded.set(cache.size() > cacheSize);
+        return result.get();
+    }
+
+    public <T> T evaluateIfPresent(Path path, Function<LookupData, T> function){
+        AtomicReference<T> result = new AtomicReference<>(null);
+        cache.computeIfPresent(path, (keyPath, cacheEntry) ->
+        {
+            result.set(function.apply(cacheEntry.lookupData.get()));
+            return cacheEntry;
+        });
+        return result.get();
+    }
+
+    public void forEach(BiConsumer<Path, LookupData> biConsumer){
+        cache.forEach((path, cacheEntry) -> {
+               biConsumer.accept(path, cacheEntry.lookupData.get());
+        });
+    }
+
+    public int size(){
+        return cache.size();
+    }
+
+    /**
+     * submit job to reap an expired cache exactly once
+     */
+    public void reapExpired(){
+        if (sizeExceeded.get()){
+            cache
+                    .entrySet()
+                    .stream()
+                    .sorted(Comparator.comparing(entry -> entry.getValue().lastTouched.get()))
+                    .skip(cacheSize)
+                    .forEach(cacheEntry -> {
+                        if (cacheEntry.getValue().tombStone.compareAndSet(false, true)){
+                            AutoFlusher.flushExecPool.submit(expire(cacheEntry.getKey()));
+                        }
+                    });
+        }
+
+        try {
+            Thread.sleep(50);
+        } catch (InterruptedException e) {
+            log.error("Reaper sleep interrupted");
+        }
+
+        AutoFlusher.flushExecPool.submit(() -> reapExpired());
+    }
+
+    public Runnable expire(Path path){
+        return () -> {
+            cache.compute(path, (keyPath, cacheEntry)->{
+
+                try {
+                    cacheEntry.lookupData.get().close();
+                } catch (IOException e) {
+                    log.error("Could not close LookupData for path {}", path);
+                } catch (Exception e){
+                    log.error("Unexpected exception while closing {}", path);
+                }
+
+                return null;
+            });
+        };
+    }
+
+}

--- a/src/main/java/com/upserve/uppend/lookup/ConcurrentCache.java
+++ b/src/main/java/com/upserve/uppend/lookup/ConcurrentCache.java
@@ -26,6 +26,10 @@ public class ConcurrentCache {
         this.cacheSize = cacheSize;
     }
 
+    public void clear() {
+        this.cache.clear();
+    }
+
     private static class CacheEntry{
         protected final AtomicLong lastTouched;
         protected final AtomicBoolean tombStone;

--- a/src/main/java/com/upserve/uppend/lookup/LongLookup.java
+++ b/src/main/java/com/upserve/uppend/lookup/LongLookup.java
@@ -200,7 +200,7 @@ public class LongLookup implements AutoCloseable, Flushable {
                 }
 
             });
-            //writeCache.clear();
+            writeCache.clear();
         }
         log.trace("closed {}", dir);
     }

--- a/src/main/java/com/upserve/uppend/lookup/LongLookup.java
+++ b/src/main/java/com/upserve/uppend/lookup/LongLookup.java
@@ -11,6 +11,7 @@ import java.lang.invoke.MethodHandles;
 import java.nio.file.*;
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.concurrent.atomic.*;
 import java.util.function.*;
 import java.util.stream.*;
 
@@ -39,8 +40,7 @@ public class LongLookup implements AutoCloseable, Flushable {
     private final int hashBytes;
     private final int hashFinalByteMask;
     private final HashFunction hashFunction;
-    private final LinkedHashMap<Path, LookupData> writeCache;
-    private final Object writeCacheDataCloseMonitor = new Object();
+    private final ConcurrentCache writeCache;
 
     public LongLookup(Path dir) {
         this(dir, DEFAULT_HASH_SIZE, DEFAULT_WRITE_CACHE_SIZE);
@@ -82,30 +82,9 @@ public class LongLookup implements AutoCloseable, Flushable {
         if (writeCacheSize == 0) {
             writeCache = null;
         } else {
-            writeCache = new LinkedHashMap<Path, LookupData>(writeCacheSize + 1, 1.1f, true) {
-                @Override
-                protected boolean removeEldestEntry(Map.Entry<Path, LookupData> eldest) {
-                    if (size() > writeCacheSize) {
-                        Path path = eldest.getKey();
-                        log.trace("cache removing {}", path);
-                        try {
-                            synchronized (writeCacheDataCloseMonitor) {
-                                eldest.getValue().close();
-                            }
-                        } catch (IOException e) {
-                            log.error("unable to close " + path, e);
-                            throw new UncheckedIOException("unable to close " + path, e);
-                        } catch (Exception e) {
-                            log.error("unexpected error closing " + path, e);
-                            throw e;
-                        }
-                        return true;
-                    }
-                    return false;
-                }
-            };
-
+            writeCache = new ConcurrentCache(writeCacheSize + 1, 1.1f);
         }
+
     }
 
     /**
@@ -114,7 +93,7 @@ public class LongLookup implements AutoCloseable, Flushable {
      * visible
      *
      * @param partition the partition to look up
-     * @param key the key to look up
+     * @param key       the key to look up
      * @return the value for the partition and key, or -1 if not found
      */
     public long get(String partition, String key) {
@@ -126,12 +105,8 @@ public class LongLookup implements AutoCloseable, Flushable {
         Path hashPath = hashPath(partition, lookupKey);
 
         if (writeCache != null) {
-            LookupData data;
-            synchronized (writeCache) {
-                data = writeCache.get(hashPath);
-            }
-            if (data != null) {
-                long value = data.get(lookupKey);
+            Long value = writeCache.evaluateIfPresent(hashPath, lookupData -> lookupData.get(lookupKey));
+            if (value != null) {
                 return value == Long.MIN_VALUE ? -1 : value;
             }
         }
@@ -145,7 +120,7 @@ public class LongLookup implements AutoCloseable, Flushable {
      * values are not visible
      *
      * @param partition the partition to look up
-     * @param key the key to look up
+     * @param key       the key to look up
      * @return the value for the partition and key, or -1 if not found
      */
     public long getFlushed(String partition, String key) {
@@ -163,27 +138,21 @@ public class LongLookup implements AutoCloseable, Flushable {
         validatePartition(partition);
         LookupKey lookupKey = new LookupKey(key);
         Path hashPath = hashPath(partition, lookupKey);
-        synchronized (writeCacheDataCloseMonitor) {
-            return loadFromCacheForWrite(hashPath).put(lookupKey, value);
-        }
+        return loadFromCacheForWrite(hashPath, lookupData -> lookupData.put(lookupKey, value));
     }
 
     public long putIfNotExists(String partition, String key, LongSupplier allocateLongFunc) {
         validatePartition(partition);
         LookupKey lookupKey = new LookupKey(key);
         Path hashPath = hashPath(partition, lookupKey);
-        synchronized (writeCacheDataCloseMonitor) {
-            return loadFromCacheForWrite(hashPath).putIfNotExists(lookupKey, allocateLongFunc);
-        }
+        return loadFromCacheForWrite(hashPath, lookupData -> lookupData.putIfNotExists(lookupKey, allocateLongFunc));
     }
 
     public long increment(String partition, String key, long delta) {
         validatePartition(partition);
         LookupKey lookupKey = new LookupKey(key);
         Path hashPath = hashPath(partition, lookupKey);
-        synchronized (writeCacheDataCloseMonitor) {
-            return loadFromCacheForWrite(hashPath).increment(lookupKey, delta);
-        }
+        return loadFromCacheForWrite(hashPath, lookupData -> lookupData.increment(lookupKey, delta));
     }
 
     public Stream<String> keys(String partition) {
@@ -218,24 +187,20 @@ public class LongLookup implements AutoCloseable, Flushable {
     @Override
     public void close() {
         if (writeCache != null) {
-            synchronized (writeCache) {
-                if (log.isTraceEnabled()) {
-                    log.trace("closing {} (~{} entries)", dir, writeCache.size());
-                }
-                synchronized (writeCacheDataCloseMonitor) {
-                    writeCache.forEach((path, data) -> {
-                        log.trace("cache removing {}", path);
-                        try {
-                            data.close();
-                        } catch (IOException e) {
-                            log.error("unable to close " + path, e);
-                            throw new UncheckedIOException("unable to close " + path, e);
-                        }
-
-                    });
-                    writeCache.clear();
-                }
+            if (log.isTraceEnabled()) {
+                log.trace("closing {} (~{} entries)", dir, writeCache.size());
             }
+            writeCache.forEach((path, data) -> {
+                log.trace("cache removing {}", path);
+                try {
+                    data.close();
+                } catch (IOException e) {
+                    log.error("unable to close " + path, e);
+                    throw new UncheckedIOException("unable to close " + path, e);
+                }
+
+            });
+            //writeCache.clear();
         }
         log.trace("closed {}", dir);
     }
@@ -248,22 +213,19 @@ public class LongLookup implements AutoCloseable, Flushable {
         if (log.isTraceEnabled()) {
             log.trace("flushing {}", dir);
         }
-        ConcurrentHashMap<Path, LookupData> cacheCopy;
-        synchronized (writeCache) {
-            cacheCopy = new ConcurrentHashMap<>(writeCache);
-        }
+
         ArrayList<Future> futures = new ArrayList<>();
-        cacheCopy.forEach((path, data) ->
-            futures.add(AutoFlusher.flushExecPool.submit(() -> {
-                try {
-                    log.trace("cache flushing {}", path);
-                    data.flush();
-                    log.trace("cache flushed {}", path);
-                } catch (Exception e) {
-                    log.error("unable to flush " + path, e);
-                }
-            }
-        )));
+        writeCache.forEach((path, data) ->
+                futures.add(AutoFlusher.flushExecPool.submit(() -> {
+                            try {
+                                log.trace("cache flushing {}", path);
+                                data.flush();
+                                log.trace("cache flushed {}", path);
+                            } catch (Exception e) {
+                                log.error("unable to flush " + path, e);
+                            }
+                        }
+                )));
         Futures.getAll(futures);
         log.trace("flushed {}", dir);
     }
@@ -283,19 +245,11 @@ public class LongLookup implements AutoCloseable, Flushable {
         }
     }
 
-    private LookupData loadFromCacheForWrite(Path hashPath) {
+    private Long loadFromCacheForWrite(Path hashPath, Function<LookupData, Long> function) {
         if (writeCache == null) {
             throw new IllegalStateException("attempting write without a write cache: " + hashPath);
         }
-        synchronized (writeCache) {
-            return writeCache.computeIfAbsent(hashPath, path -> {
-                log.trace("cache loading {}", hashPath);
-                return new LookupData(
-                        hashPath.resolve("data"),
-                        hashPath.resolve("meta")
-                    );
-            });
-        }
+        return writeCache.compute(hashPath, function);
     }
 
     private Path hashPath(String partition, LookupKey key) {
@@ -332,7 +286,7 @@ public class LongLookup implements AutoCloseable, Flushable {
         // Also see hashPath method in this class
         Stream<String> paths = IntStream
                 .range(0, hashFinalByteMask + 1)
-                .mapToObj(i ->  String.format("%02x/data", i));
+                .mapToObj(i -> String.format("%02x/data", i));
 
         for (int i = 1; i < hashBytes; i++) {
             paths = paths


### PR DESCRIPTION
Initial implementation for a concurrent LongLookup Cache

Benchmark Performance:
2560 of 2560 cached (`benchmark -c 2570 -h 256 -p 10 -n 5000000 -k 1000000  write`)
Master: 154.30 seconds
Concurrent Lookups: 92.44 seconds

2240 of 2560 cached (`benchmark -c 2240 -h 256 -p 10 -n 5000000 -k 1000000  write`)
Master: 1724.25 seconds
Concurrent Lookups: 121.40 seconds

[detail logs](https://gist.github.com/dstuebe/0e0d9746cab93e192d23181fb57ea69e) 

*note the [change](https://github.com/upserve/uppend/pull/67/commits/b357db02c8e40e6a0246225f0c016be06e91ea9e) to the benchmark blob size was applied to both the master branch and the experimental concurrent lookups branch for the benchmark tests


