### PR TITLE
Add a test that reads the last block and remove error condition

### DIFF
--- a/src/main/java/com/upserve/uppend/BlockedLongs.java
+++ b/src/main/java/com/upserve/uppend/BlockedLongs.java
@@ -260,9 +260,6 @@ public class BlockedLongs implements AutoCloseable, Flushable {
             if (numRead == -1) {
                 return null;
             }
-            if (numRead != blockSize) {
-                throw new RuntimeException("read bad block size from " + file + " at pos " + pos + ": got " + numRead + ", expected " + blockSize);
-            }
         } catch (Exception e) {
             throw new RuntimeException("unable to read block at pos " + pos + ": " + file, e);
         }


### PR DESCRIPTION

It seems like this error condition for reading less than a complete block is unnecessary.
Calling read on the last block will not return a full buffer until the next block is written. That seems to be fine. Is there some condition in which this should be an error?

The test I added happened to hit this condition, probably better ways to test it though.