### PR TITLE
More parallel blocks

### DIFF
--- a/src/main/java/com/upserve/uppend/BlockedLongs.java
+++ b/src/main/java/com/upserve/uppend/BlockedLongs.java
@@ -16,8 +16,13 @@ import java.util.stream.*;
 public class BlockedLongs implements AutoCloseable, Flushable {
     private static final Logger log = org.slf4j.LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
+    private static final int LOCK_SIZE = 1024;
+    private final Object[] posLocks = IntStream.range(0, LOCK_SIZE).mapToObj(i -> new Object()).toArray();
+
     private static final int PAGE_SIZE = 4 * 1024 * 1024; // allocate 4 MB chunks
     private static final int MAX_PAGES = 1024 * 1024; // max 4 TB (~800 MB heap)
+    
+    private static final int PRELOAD = 3;
 
     private final Path file;
 
@@ -34,6 +39,9 @@ public class BlockedLongs implements AutoCloseable, Flushable {
     private final AtomicLong posMem;
 
     private final AtomicBoolean closed = new AtomicBoolean(false);
+
+    private final AtomicInteger currentMaxPage = new AtomicInteger();
+    private int currentLoadedPage =0;
 
     public BlockedLongs(Path file, int valuesPerBlock) {
         if (file == null) {
@@ -89,6 +97,14 @@ public class BlockedLongs implements AutoCloseable, Flushable {
                 throw new IllegalStateException("pos (" + pos + ") > size of " + file + " (" + blocks.size() + "): " + posFile);
             }
             posMem = new AtomicLong(pos);
+
+            int pageIndex = (int) pos / PAGE_SIZE;
+
+            currentMaxPage.set(pageIndex);
+
+            loadToPage(pageIndex + PRELOAD);
+
+
         } catch (IOException e) {
             throw new UncheckedIOException("unable to init blocks pos file: " + posFile, e);
         }
@@ -109,39 +125,49 @@ public class BlockedLongs implements AutoCloseable, Flushable {
         return pos;
     }
 
-    public synchronized void append(final long pos, final long val) {
+    /**
+     * For a given starting block position get an object to synchronize on using the modulo of the position
+     * @param pos the position of a starting block
+     * @return an Object on which we can lock
+     */
+    private Object getLockObjectFor(long pos){
+        return posLocks[(int) (pos % LOCK_SIZE)];
+    }
+    public void append(final long pos, final long val) {
         log.trace("appending value {} to {} at {}", val, file, pos);
 
         // size | -next
         // prev | -last
 
-        final long prev = readLong(pos + 8);
-        if (prev > 0) {
-            throw new IllegalStateException("append called at non-starting block: pos=" + pos + " in path: " + file);
-        }
-        final long last = prev == 0 ? pos : -prev;
-        final long size = readLong(last);
-        if (size < 0) {
-            throw new IllegalStateException("last block has a next: pos=" + pos + " in path: " + file);
-        }
-        if (size > valuesPerBlock) {
-            throw new IllegalStateException("too high num values: expected <= " + valuesPerBlock + ", got " + size + ": pos=" + pos + " in path: " + file);
-        }
-        if (size == valuesPerBlock) {
-            long newPos = allocate();
-            // write new value in new block
-            writeLong(newPos, 1);
-            writeLong(newPos + 8, last);
-            writeLong(newPos + 16, val);
-            // link to last->next
-            writeLong(last, -newPos);
-            // link to first->last
-            writeLong(pos + 8, -newPos);
-        } else {
-            writeLong(last + 16 + 8 * size, val);
-            writeLong(last, size + 1);
-        }
+        synchronized (getLockObjectFor(pos)) {
 
+            final long prev = readLong(pos + 8);
+            if (prev > 0) {
+                throw new IllegalStateException("append called at non-starting block: pos=" + pos + " in path: " + file);
+            }
+            final long last = prev == 0 ? pos : -prev;
+            final long size = readLong(last);
+            if (size < 0) {
+                throw new IllegalStateException("last block has a next: pos=" + pos + " in path: " + file);
+            }
+            if (size > valuesPerBlock) {
+                throw new IllegalStateException("too high num values: expected <= " + valuesPerBlock + ", got " + size + ": pos=" + pos + " in path: " + file);
+            }
+            if (size == valuesPerBlock) {
+                long newPos = allocate();
+                // write new value in new block
+                writeLong(newPos, 1);
+                writeLong(newPos + 8, last);
+                writeLong(newPos + 16, val);
+                // link to last->next
+                writeLong(last, -newPos);
+                // link to first->last
+                writeLong(pos + 8, -newPos);
+            } else {
+                writeLong(last + 16 + 8 * size, val);
+                writeLong(last, size + 1);
+            }
+        }
         log.trace("appended value {} to {} at {}", val, file, pos);
     }
 
@@ -159,32 +185,33 @@ public class BlockedLongs implements AutoCloseable, Flushable {
 
         // size | -next
         // prev | -last
+        synchronized (getLockObjectFor(pos)) {
+            long size = buf.getLong();
+            buf.getLong();
 
-        long size = buf.getLong();
-        buf.getLong();
-
-        if (size < 0) {
-            long nextPos = -size;
-            long[] values = new long[valuesPerBlock];
-            for (int i = 0; i < valuesPerBlock; i++) {
-                values[i] = buf.getLong();
+            if (size < 0) {
+                long nextPos = -size;
+                long[] values = new long[valuesPerBlock];
+                for (int i = 0; i < valuesPerBlock; i++) {
+                    values[i] = buf.getLong();
+                }
+                return LongStreams.lazyConcat(Arrays.stream(values), () -> values(nextPos));
+            } else if (size > valuesPerBlock) {
+                throw new IllegalStateException("too high num values: expected <= " + valuesPerBlock + ", got " + size);
+            } else if (size == 0) {
+                return LongStream.empty();
+            } else {
+                int numValues = (int) size;
+                long[] values = new long[numValues];
+                for (int i = 0; i < numValues; i++) {
+                    values[i] = buf.getLong();
+                }
+                if (log.isTraceEnabled()) {
+                    String valuesStr = Arrays.toString(values);
+                    log.trace("got values from {} at {}: {}", file, pos, valuesStr);
+                }
+                return Arrays.stream(values);
             }
-            return LongStreams.lazyConcat(Arrays.stream(values), () -> values(nextPos));
-        } else if (size > valuesPerBlock) {
-            throw new IllegalStateException("too high num values: expected <= " + valuesPerBlock + ", got " + size);
-        } else if (size == 0) {
-            return LongStream.empty();
-        } else {
-            int numValues = (int) size;
-            long[] values = new long[numValues];
-            for (int i = 0; i < numValues; i++) {
-                values[i] = buf.getLong();
-            }
-            if (log.isTraceEnabled()) {
-                String valuesStr = Arrays.toString(values);
-                log.trace("got values from {} at {}: {}", file, pos, valuesStr);
-            }
-            return Arrays.stream(values);
         }
     }
 
@@ -227,20 +254,23 @@ public class BlockedLongs implements AutoCloseable, Flushable {
         return value;
     }
 
-    public synchronized void clear() {
+    public void clear() {
         log.debug("clearing {}", file);
         try {
             blocks.truncate(0);
             posBuf.putLong(0, 0);
             posMem.set(0);
             Arrays.fill(pages, null);
+            currentMaxPage.set(0);
+            currentLoadedPage = 0;
+            loadToPage(PRELOAD);
         } catch (IOException e) {
             throw new UncheckedIOException("unable to clear", e);
         }
     }
 
     @Override
-    public synchronized void close() throws Exception {
+    public void close() throws Exception {
         log.trace("closing {}", file);
         flush();
         closed.set(true);
@@ -249,7 +279,7 @@ public class BlockedLongs implements AutoCloseable, Flushable {
     }
 
     @Override
-    public synchronized void flush() {
+    public void flush() {
         log.trace("flushing {}", file);
         try {
             for (MappedByteBuffer page : pages) {
@@ -297,16 +327,38 @@ public class BlockedLongs implements AutoCloseable, Flushable {
             throw new RuntimeException("page index exceeded max int: " + pageIndexLong);
         }
         int pageIndex = (int) pageIndexLong;
-        MappedByteBuffer page = pages[pageIndex];
-        if (page == null) {
-            long pageStart = (long) pageIndex * PAGE_SIZE;
-            try {
-                page = blocks.map(FileChannel.MapMode.READ_WRITE, pageStart, PAGE_SIZE);
-            } catch (IOException e) {
-                throw new UncheckedIOException("unable to map page at pos " + pos + " (" + pageStart + " + " + PAGE_SIZE + ") in " + file, e);
-            }
-            pages[pageIndex] = page;
+
+        int prev = currentMaxPage.getAndUpdate(current -> pageIndex > current ? pageIndex: current);
+
+        if (pageIndex > prev){
+            loadToPage(pageIndex + PRELOAD);
         }
-        return page;
+
+        MappedByteBuffer buffer = pages[pageIndex];
+
+        if (buffer == null){
+            log.error("Buffer was null for page {}", pageIndex);
+        }
+
+        return buffer;
+    }
+
+    private synchronized void loadToPage(int pageIndex){
+        for (int i=currentLoadedPage; i < pageIndex; i++) {
+            loadPage(i);
+        }
+        currentLoadedPage = pageIndex;
+    }
+
+
+    private void loadPage(int pageIndex){
+        long pageStart = (long) pageIndex * PAGE_SIZE;
+        try {
+            if (pages[pageIndex] == null) {
+                pages[pageIndex] = blocks.map(FileChannel.MapMode.READ_WRITE, pageStart, PAGE_SIZE);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("unable to map page at index " + pageIndex + " (" + pageStart + " + " + PAGE_SIZE + ") in " + file, e);
+        }
     }
 }


### PR DESCRIPTION
@bfulton This works better - syncing on an array of objects indexed by Modulo of POS

This trick is in not causing every thread to still hit the synchronized block to make sure they Page exists before getting the mapped buffer.

The getAndUpdate works reasonable well - I have not seen a null returned in practice yet, but it would certainly be possible.