### PR TITLE
Add scan method to counter store and append store

### DIFF
--- a/src/main/java/com/upserve/uppend/AppendOnlyObjectStore.java
+++ b/src/main/java/com/upserve/uppend/AppendOnlyObjectStore.java
@@ -21,8 +21,8 @@ public class AppendOnlyObjectStore<T> implements AutoCloseable, Flushable {
      * Constructs new instance, wrapping the underlying {@code AppendOnlyStore},
      * and using the supplied serialization/deserialization functions.
      *
-     * @param store        the append-only store to keep the serialized byte arrays
-     * @param serializer   the serialization function
+     * @param store the append-only store to keep the serialized byte arrays
+     * @param serializer the serialization function
      * @param deserializer the deserialization function
      */
     public AppendOnlyObjectStore(AppendOnlyStore store, Function<T, byte[]> serializer, Function<byte[], T> deserializer) {
@@ -35,8 +35,8 @@ public class AppendOnlyObjectStore<T> implements AutoCloseable, Flushable {
      * Append an object under a given key
      *
      * @param partition the partition to store under
-     * @param key       the key to store under
-     * @param value     the value to append
+     * @param key the key to store under
+     * @param value the value to append
      * @throws IllegalArgumentException if partition is invalid
      */
     public void append(String partition, String key, T value) {
@@ -48,9 +48,9 @@ public class AppendOnlyObjectStore<T> implements AutoCloseable, Flushable {
      * parallel
      *
      * @param partition the key under which to retrieve
-     * @param key       the key under which to retrieve
-     * @return a stream of the stored objects
+     * @param key the key under which to retrieve
      * @throws IllegalArgumentException if partition is invalid
+     * @return a stream of the stored objects
      */
     public Stream<T> read(String partition, String key) {
         return store.read(partition, key).map(deserializer);
@@ -61,9 +61,9 @@ public class AppendOnlyObjectStore<T> implements AutoCloseable, Flushable {
      * the order they were stored
      *
      * @param partition the partition under which to retrieve
-     * @param key       the key under which to retrieve
-     * @return a stream of the stored objects in storage order
+     * @param key the key under which to retrieve
      * @throws IllegalArgumentException if partition is invalid
+     * @return a stream of the stored objects in storage order
      */
     public Stream<T> readSequential(String partition, String key) {
         return store.readSequential(partition, key).map(deserializer);
@@ -73,9 +73,9 @@ public class AppendOnlyObjectStore<T> implements AutoCloseable, Flushable {
      * Read the last object that was stored under a given partition and key
      *
      * @param partition the partition under which to retrieve
-     * @param key       the key under which to retrieve
-     * @return the stored object, or null if none
+     * @param key the key under which to retrieve
      * @throws IllegalArgumentException if partition is invalid
+     * @return the stored object, or null if none
      */
     public T readLast(String partition, String key) {
         return deserializer.apply(store.readLast(partition, key));
@@ -86,9 +86,9 @@ public class AppendOnlyObjectStore<T> implements AutoCloseable, Flushable {
      * parallel, skipping the write cache so that unflushed data is not visible
      *
      * @param partition the key under which to retrieve
-     * @param key       the key under which to retrieve
-     * @return a stream of the stored objects
+     * @param key the key under which to retrieve
      * @throws IllegalArgumentException if partition is invalid
+     * @return a stream of the stored objects
      */
     public Stream<T> readFlushed(String partition, String key) {
         return store.readFlushed(partition, key).map(deserializer);
@@ -100,9 +100,9 @@ public class AppendOnlyObjectStore<T> implements AutoCloseable, Flushable {
      * data is not visible
      *
      * @param partition the partition under which to retrieve
-     * @param key       the key under which to retrieve
-     * @return a stream of the stored objects in storage order
+     * @param key the key under which to retrieve
      * @throws IllegalArgumentException if partition is invalid
+     * @return a stream of the stored objects in storage order
      */
     public Stream<T> readSequentialFlushed(String partition, String key) {
         return store.readSequentialFlushed(partition, key).map(deserializer);
@@ -113,9 +113,9 @@ public class AppendOnlyObjectStore<T> implements AutoCloseable, Flushable {
      * skipping the write cache so that unflushed data is not visible
      *
      * @param partition the partition under which to retrieve
-     * @param key       the key under which to retrieve
-     * @return the stored object, or null if none
+     * @param key the key under which to retrieve
      * @throws IllegalArgumentException if partition is invalid
+     * @return the stored object, or null if none
      */
     public T readLastFlushed(String partition, String key) {
         return deserializer.apply(store.readLastFlushed(partition, key));
@@ -125,8 +125,8 @@ public class AppendOnlyObjectStore<T> implements AutoCloseable, Flushable {
      * Enumerate the keys in the data store
      *
      * @param partition the key under which to retrieve
-     * @return a stream of string keys
      * @throws IllegalArgumentException if partition is invalid
+     * @return a stream of string keys
      */
     public Stream<String> keys(String partition) {
         return store.keys(partition);
@@ -142,13 +142,31 @@ public class AppendOnlyObjectStore<T> implements AutoCloseable, Flushable {
     }
 
     /**
-     * Scan all the keys and values in a partition return a stream of entries for each key
+     * Scan all the keys and values in a partition, returning a stream of
+     * entries for each key
+     *
      * @param partition the name of the partition
-     * @return a Stream of Entries containing the key and a stream of values
+     * @return a stream of entries of key to stream of object values
      */
     public Stream<Map.Entry<String, Stream<T>>> scan(String partition) {
         return store.scan(partition).map(entry ->
-                Maps.immutableEntry(entry.getKey(), entry.getValue().map(deserializer)));
+                Maps.immutableEntry(
+                        entry.getKey(),
+                        entry.getValue().map(deserializer)
+                ));
+    }
+
+    /**
+     * Scan all the keys and values in a partition, calling the given function
+     * with each key and stream of object values
+     *
+     * @param partition the name of the partition
+     * @param callback function to call for each key and stream of values
+     */
+    public void scan(String partition, BiConsumer<String, Stream<T>> callback) {
+        store.scan(partition, (key, byteValues) ->
+                callback.accept(key, byteValues.map(deserializer))
+        );
     }
 
     /**

--- a/src/main/java/com/upserve/uppend/FileCounterStore.java
+++ b/src/main/java/com/upserve/uppend/FileCounterStore.java
@@ -6,6 +6,7 @@ import org.slf4j.Logger;
 import java.lang.invoke.MethodHandles;
 import java.nio.file.Path;
 import java.util.Map;
+import java.util.function.ObjLongConsumer;
 import java.util.stream.Stream;
 
 public class FileCounterStore extends FileStore implements CounterStore {
@@ -56,6 +57,11 @@ public class FileCounterStore extends FileStore implements CounterStore {
     @Override
     public Stream<Map.Entry<String, Long>> scan(String partition) {
         return lookup.scan(partition);
+    }
+
+    @Override
+    public void scan(String partition, ObjLongConsumer<String> callback) {
+        lookup.scan(partition, callback);
     }
 
     @Override

--- a/src/main/java/com/upserve/uppend/FileCounterStore.java
+++ b/src/main/java/com/upserve/uppend/FileCounterStore.java
@@ -5,6 +5,7 @@ import org.slf4j.Logger;
 
 import java.lang.invoke.MethodHandles;
 import java.nio.file.Path;
+import java.util.Map;
 import java.util.stream.Stream;
 
 public class FileCounterStore extends FileStore implements CounterStore {
@@ -50,6 +51,11 @@ public class FileCounterStore extends FileStore implements CounterStore {
     public Stream<String> partitions() {
         log.trace("getting partitions");
         return lookup.partitions();
+    }
+
+    @Override
+    public Stream<Map.Entry<String, Long>> scan(String partition) {
+        return lookup.scan(partition);
     }
 
     @Override

--- a/src/main/java/com/upserve/uppend/ReadOnlyAppendOnlyStore.java
+++ b/src/main/java/com/upserve/uppend/ReadOnlyAppendOnlyStore.java
@@ -1,6 +1,7 @@
 package com.upserve.uppend;
 
 import java.util.Map;
+import java.util.function.BiConsumer;
 import java.util.stream.Stream;
 
 /**
@@ -57,9 +58,20 @@ public interface ReadOnlyAppendOnlyStore extends AutoCloseable {
     Stream<String> partitions();
 
     /**
-     * Scan the given partition returning a stream of the contents including the key
+     * Scan all the keys and values in a partition, returning a stream of
+     * entries for each key
+     *
      * @param partition the partition to scan
-     * @return a stream of entries containing the key and the bytes
+     * @return a stream of entries of key to stream of byte array values
      */
     Stream<Map.Entry<String, Stream<byte[]>>> scan(String partition);
+
+    /**
+     * Scan the given partition, calling the given function with each key and
+     * stream of byte array values
+     *
+     * @param partition the partition to scan
+     * @param callback function to call for each key and stream of values
+     */
+    void scan(String partition, BiConsumer<String, Stream<byte[]>> callback);
 }

--- a/src/main/java/com/upserve/uppend/ReadOnlyAppendOnlyStore.java
+++ b/src/main/java/com/upserve/uppend/ReadOnlyAppendOnlyStore.java
@@ -1,5 +1,6 @@
 package com.upserve.uppend;
 
+import java.util.Map;
 import java.util.stream.Stream;
 
 /**
@@ -54,4 +55,11 @@ public interface ReadOnlyAppendOnlyStore extends AutoCloseable {
      * @return a stream of string partition
      */
     Stream<String> partitions();
+
+    /**
+     * Scan the given partition returning a stream of the contents including the key
+     * @param partition the partition to scan
+     * @return a stream of entries containing the key and the bytes
+     */
+    Stream<Map.Entry<String, Stream<byte[]>>> scan(String partition);
 }

--- a/src/main/java/com/upserve/uppend/ReadOnlyCounterStore.java
+++ b/src/main/java/com/upserve/uppend/ReadOnlyCounterStore.java
@@ -1,7 +1,8 @@
 package com.upserve.uppend;
 
 import java.util.Map;
-import java.util.stream.Stream;
+import java.util.function.*;
+import java.util.stream.*;
 
 public interface ReadOnlyCounterStore extends AutoCloseable {
     /**
@@ -31,9 +32,20 @@ public interface ReadOnlyCounterStore extends AutoCloseable {
     Stream<String> partitions();
 
     /**
-     * Scan the given partition returning a stream of the contents including the key
+     * Scan all the keys and values in a partition, returning a stream of
+     * entries
+     *
      * @param partition the partition to scan
-     * @return a stream of entries containing the key and the count
+     * @return a stream of entries of key to counter values
      */
     Stream<Map.Entry<String, Long>> scan(String partition);
+
+    /**
+     * Scan the given partition, calling the given function with each key and
+     * counter value
+     *
+     * @param partition the partition to scan
+     * @param callback function to call for each key and value
+     */
+    void scan(String partition, ObjLongConsumer<String> callback);
 }

--- a/src/main/java/com/upserve/uppend/ReadOnlyCounterStore.java
+++ b/src/main/java/com/upserve/uppend/ReadOnlyCounterStore.java
@@ -1,5 +1,6 @@
 package com.upserve.uppend;
 
+import java.util.Map;
 import java.util.stream.Stream;
 
 public interface ReadOnlyCounterStore extends AutoCloseable {
@@ -28,4 +29,11 @@ public interface ReadOnlyCounterStore extends AutoCloseable {
      * @return a stream of string partition
      */
     Stream<String> partitions();
+
+    /**
+     * Scan the given partition returning a stream of the contents including the key
+     * @param partition the partition to scan
+     * @return a stream of entries containing the key and the count
+     */
+    Stream<Map.Entry<String, Long>> scan(String partition);
 }

--- a/src/main/java/com/upserve/uppend/lookup/LongLookup.java
+++ b/src/main/java/com/upserve/uppend/lookup/LongLookup.java
@@ -215,6 +215,16 @@ public class LongLookup implements AutoCloseable, Flushable {
                 });
     }
 
+    /**
+     * Scan the long lookups for a given partition streaming the key and long
+     * @param partition the partition name to scan
+     * @return a Stream of entries containing key and long
+     */
+    public Stream<Map.Entry<String, Long>> scan(String partition) {
+        validatePartition(partition);
+        return hashPaths(partition).flatMap(LookupData::scan);
+    }
+
     @Override
     public void close() {
         if (writeCache != null) {

--- a/src/main/java/com/upserve/uppend/lookup/LongLookup.java
+++ b/src/main/java/com/upserve/uppend/lookup/LongLookup.java
@@ -206,23 +206,30 @@ public class LongLookup implements AutoCloseable, Flushable {
                 .map(File::getName);
     }
 
-    public void scan(String partition, BiConsumer<String, Long> keyValueFunction) {
+    /**
+     * Scan the long lookups for a given partition streaming the key and long
+     *
+     * @param partition the partition to scan
+     * @return a stream of entries of key and long value
+     */
+    public Stream<Map.Entry<String, Long>> scan(String partition) {
+        validatePartition(partition);
+        return hashPaths(partition).flatMap(LookupData::scan);
+    }
+
+    /**
+     * Scan a partition and call a function for each key and value
+     *
+     * @param partition the partition to scan
+     * @param keyValueFunction function to call for each key and long value
+     */
+    public void scan(String partition, ObjLongConsumer<String> keyValueFunction) {
         validatePartition(partition);
 
         hashPaths(partition)
                 .forEach(p -> {
                     LookupData.scan(p, keyValueFunction);
                 });
-    }
-
-    /**
-     * Scan the long lookups for a given partition streaming the key and long
-     * @param partition the partition name to scan
-     * @return a Stream of entries containing key and long
-     */
-    public Stream<Map.Entry<String, Long>> scan(String partition) {
-        validatePartition(partition);
-        return hashPaths(partition).flatMap(LookupData::scan);
     }
 
     @Override

--- a/src/main/java/com/upserve/uppend/lookup/LookupData.java
+++ b/src/main/java/com/upserve/uppend/lookup/LookupData.java
@@ -1,5 +1,6 @@
 package com.upserve.uppend.lookup;
 
+import com.google.common.collect.Maps;
 import com.upserve.uppend.Blobs;
 import com.upserve.uppend.util.*;
 import it.unimi.dsi.fastutil.objects.*;
@@ -431,6 +432,78 @@ public class LookupData implements AutoCloseable, Flushable {
             } catch (IOException e) {
                 log.error("trouble closing: " + keysPath, e);
             }
+        }
+    }
+
+    static Stream<Map.Entry<String, Long>> scan(Path path) {
+        if (Files.notExists(path)) {
+            return Stream.empty();
+        }
+        KeyLongIterator iter;
+        try {
+            iter = new KeyLongIterator(path);
+        } catch (IOException e) {
+            throw new UncheckedIOException("unable to create key iterator for path: " + path, e);
+        }
+        Spliterator<Map.Entry<String, Long>> spliter = Spliterators.spliterator(
+                iter,
+                iter.getNumKeys(),
+                Spliterator.DISTINCT | Spliterator.NONNULL | Spliterator.SIZED
+        );
+        return StreamSupport.stream(spliter, true).onClose(iter::close);
+    }
+
+    private static class KeyLongIterator implements Iterator<Map.Entry<String, Long>>, AutoCloseable {
+        private final Path path;
+        private final Path keysPath;
+        private final FileChannel chan;
+
+        private final Blobs keyBlobs;
+        private final int numKeys;
+        private int keyIndex = 0;
+        private final DataInputStream dis;
+
+        KeyLongIterator(Path path) throws IOException {
+            this.path = path;
+            chan = FileChannel.open(path, StandardOpenOption.READ);
+            chan.position(0);
+            keysPath = path.resolveSibling("keys");
+            keyBlobs = new Blobs(keysPath);
+            numKeys = (int) chan.size() / 16;
+            dis = new DataInputStream(new BufferedInputStream(Channels.newInputStream(chan), 8192));
+        }
+
+        int getNumKeys() {
+            return numKeys;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return keyIndex < numKeys;
+        }
+
+        @Override
+        public Map.Entry<String, Long> next() {
+            try {
+                long keyPos = dis.readLong();
+                byte[] keyBytes = keyBlobs.read(keyPos);
+                LookupKey key = new LookupKey(keyBytes);
+                long val = dis.readLong();
+                keyIndex++;
+                return Maps.immutableEntry(key.string(), val);
+            } catch (IOException e) {
+                throw new UncheckedIOException("unable to read at key index " + keyIndex + " from " + path, e);
+            }
+        }
+
+        @Override
+        public void close() {
+            try {
+                chan.close();
+            } catch (IOException e) {
+                log.error("trouble closing: " + path, e);
+            }
+            keyBlobs.close();
         }
     }
 

--- a/src/main/java/com/upserve/uppend/metrics/AppendOnlyStoreWithMetrics.java
+++ b/src/main/java/com/upserve/uppend/metrics/AppendOnlyStoreWithMetrics.java
@@ -4,6 +4,7 @@ import com.codahale.metrics.*;
 import com.upserve.uppend.AppendOnlyStore;
 
 import java.util.Map;
+import java.util.function.BiConsumer;
 import java.util.stream.Stream;
 
 public class AppendOnlyStoreWithMetrics implements AppendOnlyStore {
@@ -169,7 +170,18 @@ public class AppendOnlyStoreWithMetrics implements AppendOnlyStore {
             return store.scan(partition);
         } finally {
             context.stop();
-        }    }
+        }
+    }
+
+    @Override
+    public void scan(String partition, BiConsumer<String, Stream<byte[]>> callback) {
+        final Timer.Context context = scanTimer.time();
+        try {
+            store.scan(partition, callback);
+        } finally {
+            context.stop();
+        }
+    }
 
     @Override
     public void clear() {

--- a/src/main/java/com/upserve/uppend/metrics/AppendOnlyStoreWithMetrics.java
+++ b/src/main/java/com/upserve/uppend/metrics/AppendOnlyStoreWithMetrics.java
@@ -3,6 +3,7 @@ package com.upserve.uppend.metrics;
 import com.codahale.metrics.*;
 import com.upserve.uppend.AppendOnlyStore;
 
+import java.util.Map;
 import java.util.stream.Stream;
 
 public class AppendOnlyStoreWithMetrics implements AppendOnlyStore {
@@ -11,6 +12,7 @@ public class AppendOnlyStoreWithMetrics implements AppendOnlyStore {
     public static final String READ_TIMER_METRIC_NAME = "readTimer";
     public static final String KEYS_TIMER_METRIC_NAME = "keysTimer";
     public static final String PARTITIONS_TIMER_METRIC_NAME = "partitionsTimer";
+    public static final String SCAN_TIMER_METRIC_NAME = "scanTimer";
     public static final String CLEAR_TIMER_METRIC_NAME = "clearTimer";
     public static final String CLOSE_TIMER_METRIC_NAME = "closeTimer";
 
@@ -25,6 +27,7 @@ public class AppendOnlyStoreWithMetrics implements AppendOnlyStore {
     private final Timer readTimer;
     private final Timer keysTimer;
     private final Timer partitionsTimer;
+    private final Timer scanTimer;
     private final Timer clearTimer;
     private final Timer closeTimer;
 
@@ -40,6 +43,7 @@ public class AppendOnlyStoreWithMetrics implements AppendOnlyStore {
         readTimer = metrics.timer(READ_TIMER_METRIC_NAME);
         keysTimer = metrics.timer(KEYS_TIMER_METRIC_NAME);
         partitionsTimer = metrics.timer(PARTITIONS_TIMER_METRIC_NAME);
+        scanTimer = metrics.timer(SCAN_TIMER_METRIC_NAME);
         clearTimer = metrics.timer(CLEAR_TIMER_METRIC_NAME);
         closeTimer = metrics.timer(CLOSE_TIMER_METRIC_NAME);
 
@@ -157,6 +161,15 @@ public class AppendOnlyStoreWithMetrics implements AppendOnlyStore {
             context.stop();
         }
     }
+
+    @Override
+    public Stream<Map.Entry<String, Stream<byte[]>>> scan(String partition) {
+        final Timer.Context context = scanTimer.time();
+        try {
+            return store.scan(partition);
+        } finally {
+            context.stop();
+        }    }
 
     @Override
     public void clear() {

--- a/src/main/java/com/upserve/uppend/metrics/CounterStoreWithMetrics.java
+++ b/src/main/java/com/upserve/uppend/metrics/CounterStoreWithMetrics.java
@@ -3,6 +3,8 @@ package com.upserve.uppend.metrics;
 import com.codahale.metrics.*;
 import com.upserve.uppend.CounterStore;
 
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
 public class CounterStoreWithMetrics implements CounterStore {
@@ -15,6 +17,7 @@ public class CounterStoreWithMetrics implements CounterStore {
     private final Timer metricsGetTimer;
     private final Timer metricsKeysTimer;
     private final Timer metricsPartitionsTimer;
+    private final Timer metricsScanTimer;
     private final Timer metricsClearTimer;
     private final Timer metricsCloseTimer;
 
@@ -28,6 +31,7 @@ public class CounterStoreWithMetrics implements CounterStore {
         metricsGetTimer = metrics.timer("get");
         metricsKeysTimer = metrics.timer("keys");
         metricsPartitionsTimer = metrics.timer("partitions");
+        metricsScanTimer = metrics.timer("scan");
         metricsClearTimer = metrics.timer("clear");
         metricsCloseTimer = metrics.timer("close");
     }
@@ -91,6 +95,15 @@ public class CounterStoreWithMetrics implements CounterStore {
             context.stop();
         }
     }
+
+    @Override
+    public Stream<Map.Entry<String, Long>> scan(String partition) {
+        final Timer.Context context = metricsScanTimer.time();
+        try {
+            return store.scan(partition);
+        } finally {
+            context.stop();
+        }    }
 
     @Override
     public void clear() {

--- a/src/main/java/com/upserve/uppend/metrics/CounterStoreWithMetrics.java
+++ b/src/main/java/com/upserve/uppend/metrics/CounterStoreWithMetrics.java
@@ -4,7 +4,7 @@ import com.codahale.metrics.*;
 import com.upserve.uppend.CounterStore;
 
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
+import java.util.function.ObjLongConsumer;
 import java.util.stream.Stream;
 
 public class CounterStoreWithMetrics implements CounterStore {
@@ -103,7 +103,18 @@ public class CounterStoreWithMetrics implements CounterStore {
             return store.scan(partition);
         } finally {
             context.stop();
-        }    }
+        }
+    }
+
+    @Override
+    public void scan(String partition, ObjLongConsumer<String> callback) {
+        final Timer.Context context = metricsScanTimer.time();
+        try {
+            store.scan(partition, callback);
+        } finally {
+            context.stop();
+        }
+    }
 
     @Override
     public void clear() {

--- a/src/test/java/com/upserve/uppend/CounterStoreTest.java
+++ b/src/test/java/com/upserve/uppend/CounterStoreTest.java
@@ -112,7 +112,7 @@ public class CounterStoreTest {
         store.increment("partition$three", "three", 3);
         store.increment("partition-four", "four", 4);
         store.increment("_2016-01-02", "five", 5);
-        assertArrayEquals(new String[]{"_2016-01-02", "partition$three", "partition-four", "partition_one", "partition_two"}, store.partitions().sorted().toArray(String[]::new));
+        assertArrayEquals(new String[] { "_2016-01-02", "partition$three", "partition-four", "partition_one", "partition_two" }, store.partitions().sorted().toArray(String[]::new));
     }
 
     @Test
@@ -139,6 +139,26 @@ public class CounterStoreTest {
     }
 
     @Test
+    public void testScanCallback() {
+        store.increment("partition_one", "one", 1);
+        store.increment("partition_one", "two", 1);
+        store.increment("partition_one", "three", 1);
+        store.increment("partition_one", "one", 1);
+        store.increment("partition_two", "one", 1);
+
+        Map<String, Long> result = new TreeMap<>();
+        store.scan("partition_one", result::put);
+
+        Map<String, Long> expected = ImmutableMap.of(
+                "one", 2L,
+                "two", 1L,
+                "three", 1L
+        );
+
+        assertEquals(expected, result);
+    }
+
+    @Test
     public void testExample() throws Exception {
         store.close();
         store = new FileCounterStore(Paths.get("build/test/file-append-only-store"), 10, true, 1, 1);
@@ -154,7 +174,7 @@ public class CounterStoreTest {
 
         store.increment("2017-11-30", "ttt-ttttt-tttt-ttttttt-ttt-tttt::tttttttttt");
 
-        assertArrayEquals(new String[]{"2017-11-30"}, store.partitions().toArray(String[]::new));
+        assertArrayEquals(new String[] { "2017-11-30" }, store.partitions().toArray(String[]::new));
         assertEquals(5, store.get("2017-11-30", "bbbbbbbb-bbbbbbb-bbbb-bbbbbbb-bbbb::bbbbbbb"));
         assertEquals(1, store.get("2017-11-30", "ccccccc-cccccccccc-ccccccc-ccccccc::ccccccc"));
         assertEquals(1, store.get("2017-11-30", "ttt-ttttt-tttt-ttttttt-ttt-tttt::tttttttttt"));

--- a/src/test/java/com/upserve/uppend/lookup/LongLookupTest.java
+++ b/src/test/java/com/upserve/uppend/lookup/LongLookupTest.java
@@ -2,7 +2,6 @@ package com.upserve.uppend.lookup;
 
 import com.google.common.hash.HashCode;
 import com.upserve.uppend.util.SafeDeleting;
-import net.bytebuddy.utility.RandomString;
 import org.junit.*;
 
 import java.io.IOException;
@@ -163,7 +162,7 @@ public class LongLookupTest {
 
         Map<String, Long> result = IntStream.range(0, (int) putCount)
                 .parallel()
-                .mapToObj(i -> RandomString.make(entropy).toLowerCase())
+                .mapToObj(i -> randomString(entropy))
                 .peek(s -> longLookup.putIfNotExists(s.substring(0,1), s, supplier))
                 .collect(
                         Collectors.groupingByConcurrent(Function.identity(),
@@ -175,5 +174,27 @@ public class LongLookupTest {
         // The sum of the counts for each key should equal the number of time put was called
         assertEquals(putCount, result.values().stream().mapToLong(val -> val).sum());
         longLookup.close();
+    }
+
+    private static final int ALPHA_NUMS_LEN = 26 + 10;
+    private static char[] ALPHA_NUMS = new char[ALPHA_NUMS_LEN];
+    static {
+        int i = 0;
+        for (char c = 'a'; c <= 'z'; c++) {
+            ALPHA_NUMS[i++] = c;
+        }
+        for (char c = '0'; c <= '9'; c++) {
+            ALPHA_NUMS[i++] = c;
+        }
+    }
+
+    private static final Random ALPHA_NUM_RANDOMNESS = new Random(1234);
+
+    private static String randomString(int len) {
+        char[] chars = new char[len];
+        for (int i = 0; i < len; i++) {
+            chars[i] = ALPHA_NUMS[ALPHA_NUM_RANDOMNESS.nextInt(ALPHA_NUMS_LEN)];
+        }
+        return new String(chars);
     }
 }


### PR DESCRIPTION
Changes:
* Add scan method to counter store and append only object store

The interface is:
`Stream<Map.Entry<String, Stream<byte[]>>> scan(String partition);`
Allowing the user to more efficiently read all the entries in a given partition while efficiently reading the lookup date from each hashPath.

An expected usage of this method might be something like:

    store.partitions()
        .parallel()
        .flatMap(store::scan)
        .collect(...)

or

    store.partitions()
        .parallel()
        .flatMap(partition -> store.scan(partition).foreach(....))
