### PR TITLE
Read only append store

### DIFF
--- a/src/main/java/com/upserve/uppend/AppendOnlyObjectStore.java
+++ b/src/main/java/com/upserve/uppend/AppendOnlyObjectStore.java
@@ -16,7 +16,7 @@ public class AppendOnlyObjectStore<T> implements AutoCloseable, Flushable {
     private final AppendOnlyStore store;
     private final Function<T, byte[]> serializer;
     private final Function<byte[], T> deserializer;
-
+    private final boolean readOnly;
     /**
      * Constructs new instance, wrapping the underlying {@code AppendOnlyStore},
      * and using the supplied serialization/deserialization functions.
@@ -26,9 +26,22 @@ public class AppendOnlyObjectStore<T> implements AutoCloseable, Flushable {
      * @param deserializer the deserialization function
      */
     public AppendOnlyObjectStore(AppendOnlyStore store, Function<T, byte[]> serializer, Function<byte[], T> deserializer) {
+        this(store, serializer, deserializer, false);
+    }
+
+    /**
+     * Constructs new instance, wrapping the underlying {@code AppendOnlyStore},
+     * and using the supplied serialization/deserialization functions.
+     *
+     * @param store the append-only store to keep the serialized byte arrays
+     * @param serializer the serialization function
+     * @param deserializer the deserialization function
+     */
+    public AppendOnlyObjectStore(AppendOnlyStore store, Function<T, byte[]> serializer, Function<byte[], T> deserializer, boolean readOnly) {
         this.store = store;
         this.serializer = serializer;
         this.deserializer = deserializer;
+        this.readOnly = readOnly;
     }
 
     /**
@@ -48,6 +61,7 @@ public class AppendOnlyObjectStore<T> implements AutoCloseable, Flushable {
      * @param value the value to append
      */
     public void append(String partition, String key, T value) {
+        if (readOnly) throw new RuntimeException("Can not append to a read only store!");
         store.append(partition, key, serializer.apply(value));
     }
 
@@ -153,6 +167,7 @@ public class AppendOnlyObjectStore<T> implements AutoCloseable, Flushable {
      * Remove all keys and values from the store.
      */
     public void clear() {
+        if (readOnly) throw new RuntimeException("This store is read only!");
         store.clear();
     }
 
@@ -163,6 +178,7 @@ public class AppendOnlyObjectStore<T> implements AutoCloseable, Flushable {
 
     @Override
     public void flush() throws IOException {
+        if (readOnly) throw new RuntimeException("This store is read only!");
         store.flush();
     }
 
@@ -188,6 +204,7 @@ public class AppendOnlyObjectStore<T> implements AutoCloseable, Flushable {
      * Used the purge the write cache and save heap space when it is not currently needed for a particular store
      */
     public void purgeWriteCache(){
+        if (readOnly) throw new RuntimeException("This store is read only!");
         store.purgeWriteCache();
     }
 

--- a/src/main/java/com/upserve/uppend/AppendOnlyStoreBuilder.java
+++ b/src/main/java/com/upserve/uppend/AppendOnlyStoreBuilder.java
@@ -61,9 +61,12 @@ public class AppendOnlyStoreBuilder {
         return this;
     }
 
-    public AppendOnlyStore build() {
+    public AppendOnlyStore build(boolean readOnly) {
         AppendOnlyStore store;
-        if (suggestedBufferSize > 0) {
+
+        if (readOnly) {
+            store = new FileAppendOnlyStore(dir, -1, false, longLookupHashSize, 0, blobsPerBlock);
+        } else if (suggestedBufferSize > 0) {
             // Add log message about ignored parameters
             store = new BufferedAppendOnlyStore(dir, true, longLookupHashSize, suggestedBufferSize, blobsPerBlock, Optional.ofNullable(executorService));
         } else {

--- a/src/main/java/com/upserve/uppend/CounterStoreBuilder.java
+++ b/src/main/java/com/upserve/uppend/CounterStoreBuilder.java
@@ -42,8 +42,14 @@ public class CounterStoreBuilder {
         return this;
     }
 
-    public CounterStore build() {
-        CounterStore store = new FileCounterStore(dir, flushDelaySeconds, true, longLookupHashSize, longLookupWriteCacheSize);
+    public CounterStore build(boolean readOnly) {
+        CounterStore store;
+
+        if (readOnly) {
+            store =new FileCounterStore(dir, -1, false, longLookupHashSize, 0);
+        } else {
+            store =new FileCounterStore(dir, flushDelaySeconds, true, longLookupHashSize, longLookupWriteCacheSize);
+        }
         if (metrics != null) {
             store = new CounterStoreWithMetrics(store, metrics);
         }
@@ -51,7 +57,7 @@ public class CounterStoreBuilder {
     }
 
     public ReadOnlyCounterStore buildReadOnly() {
-        return new FileCounterStore(dir, -1, false, longLookupHashSize, 1);
+        return new FileCounterStore(dir, -1, false, longLookupHashSize, 0);
     }
 
     @Override

--- a/src/main/java/com/upserve/uppend/cli/benchmark/Benchmark.java
+++ b/src/main/java/com/upserve/uppend/cli/benchmark/Benchmark.java
@@ -56,7 +56,7 @@ public class Benchmark {
 
         switch (mode) {
             case readwrite:
-                testInstance = builder.build();
+                testInstance = builder.build(false);
                 testReadOnlyInstance = testInstance;
                 writer = simpleWriter();
                 reader = simpleReader();
@@ -72,7 +72,7 @@ public class Benchmark {
                 break;
 
             case write:
-                testInstance = builder.build();
+                testInstance = builder.build(false);
                 testReadOnlyInstance = testInstance;
                 writer = simpleWriter();
                 reader = BenchmarkReader.noop();

--- a/src/test/java/com/upserve/uppend/AppendOnlyStoreBuilderTest.java
+++ b/src/test/java/com/upserve/uppend/AppendOnlyStoreBuilderTest.java
@@ -15,7 +15,7 @@ public class AppendOnlyStoreBuilderTest {
         Path path = Paths.get("build/tmp/test/append-only-store-builder");
         SafeDeleting.removeDirectory(path);
         MetricRegistry metrics = new MetricRegistry();
-        AppendOnlyStore store = Uppend.store(path).withMetrics(metrics).build();
+        AppendOnlyStore store = Uppend.store(path).withMetrics(metrics).build(false);
         store.flush();
         assertEquals(1, metrics.getTimers().get(AppendOnlyStoreWithMetrics.FLUSH_TIMER_METRIC_NAME).getCount());
     }

--- a/src/test/java/com/upserve/uppend/AppendOnlyStoreTest.java
+++ b/src/test/java/com/upserve/uppend/AppendOnlyStoreTest.java
@@ -14,7 +14,7 @@ import static org.junit.Assert.*;
 
 public class AppendOnlyStoreTest {
     private AppendOnlyStore newStore() {
-        return new AppendOnlyStoreBuilder().withDir(Paths.get("build/test/file-append-only-store")).withLongLookupHashSize(32).build();
+        return new AppendOnlyStoreBuilder().withDir(Paths.get("build/test/file-append-only-store")).withLongLookupHashSize(32).build(false);
     }
 
     private AppendOnlyStore store;

--- a/src/test/java/com/upserve/uppend/CounterStoreBuilderTest.java
+++ b/src/test/java/com/upserve/uppend/CounterStoreBuilderTest.java
@@ -14,7 +14,7 @@ public class CounterStoreBuilderTest {
         Path path = Paths.get("build/tmp/test/counter-store-builder");
         SafeDeleting.removeDirectory(path);
         MetricRegistry metrics = new MetricRegistry();
-        CounterStore store = Uppend.counterStore(path).withMetrics(metrics).build();
+        CounterStore store = Uppend.counterStore(path).withMetrics(metrics).build(false);
         store.flush();
         assertEquals(1, metrics.getTimers().get("flush").getCount());
     }

--- a/src/test/java/com/upserve/uppend/CounterStoreTest.java
+++ b/src/test/java/com/upserve/uppend/CounterStoreTest.java
@@ -15,7 +15,7 @@ public class CounterStoreTest {
     private static final Logger log = org.slf4j.LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     private CounterStore newStore() {
-        return new CounterStoreBuilder().withDir(Paths.get("build/test/file-append-only-store")).build();
+        return new CounterStoreBuilder().withDir(Paths.get("build/test/file-append-only-store")).build(false);
     }
 
     private CounterStore store;

--- a/src/test/java/com/upserve/uppend/DocExamplesTests.java
+++ b/src/test/java/com/upserve/uppend/DocExamplesTests.java
@@ -25,7 +25,7 @@ public class DocExamplesTests {
         SafeDeleting.removeTempPath(Paths.get("build/tmp-db"));
 
         // *** START SNIPPET ***
-        AppendOnlyStore db = Uppend.store("build/tmp-db").build();
+        AppendOnlyStore db = Uppend.store("build/tmp-db").build(false);
 
         db.append("my-partition", "my-key", "value-1".getBytes());
         db.append("my-partition", "my-key", "value-2".getBytes());

--- a/src/test/java/com/upserve/uppend/UppendTest.java
+++ b/src/test/java/com/upserve/uppend/UppendTest.java
@@ -20,7 +20,7 @@ public class UppendTest {
         final Path path = Paths.get(pathStr);
         SafeDeleting.removeTempPath(path);
         assertFalse(Files.exists(path));
-        AppendOnlyStore store = Uppend.store(pathStr).build();
+        AppendOnlyStore store = Uppend.store(pathStr).build(false);
         store.append("partition", "foo", "bar".getBytes());
         assertTrue(Files.exists(path));
         store.flush();
@@ -37,7 +37,7 @@ public class UppendTest {
         final Path path = Paths.get(pathStr);
         SafeDeleting.removeTempPath(path);
         assertFalse(Files.exists(path));
-        CounterStore store = Uppend.counterStore(pathStr).build();
+        CounterStore store = Uppend.counterStore(pathStr).build(false);
         store.increment("partition", "foo", 5);
         assertTrue(Files.exists(path));
         store.flush();


### PR DESCRIPTION

Allow the builder to return a store without locking which can not write.
The append and flush methods will throw if called in the AppendOnlyObjectStore.
The underlying AppendOnlyStore objects are open for writing... we should fix that.