### PR TITLE
Use striped blobs files with approximate length in the position

### DIFF
--- a/src/main/java/com/upserve/uppend/Blobs.java
+++ b/src/main/java/com/upserve/uppend/Blobs.java
@@ -1,6 +1,6 @@
 package com.upserve.uppend;
 
-import com.google.common.primitives.Bytes;
+import com.google.common.primitives.*;
 import com.upserve.uppend.util.ThreadLocalByteBuffers;
 import org.slf4j.Logger;
 
@@ -9,139 +9,180 @@ import java.lang.invoke.MethodHandles;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.*;
+import java.util.*;
 import java.util.concurrent.atomic.*;
 
 public class Blobs implements AutoCloseable, Flushable {
     private static final Logger log = org.slf4j.LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-    private final Path file;
+    private final Path dir;
 
-    private final FileChannel blobs;
-    private final AtomicLong blobPosition;
+    private static final int STRIPES = 256;
+    private static final int STRIPE_MASK = STRIPES - 1;
+    private static final long MAX_POSITION = 256L * 256L * 256L * 256L * 256L * 256L; // 6 Bytes allows 256TB per stripe file
+
+    // Replace with an array
+    private final FileChannel[] blobChannels;
+    private final AtomicLong[] blobFilePositions;
+    private final AtomicInteger nextStripe;
 
     private final AtomicBoolean closed = new AtomicBoolean(false);
 
-    public Blobs(Path file) {
-        this.file = file;
+    public Blobs(Path blobDir) {
+        this.dir = blobDir;
 
-        Path dir = file.getParent();
         try {
             Files.createDirectories(dir);
         } catch (IOException e) {
             throw new UncheckedIOException("unable to mkdirs: " + dir, e);
         }
 
-        try {
-            blobs = FileChannel.open(file, StandardOpenOption.CREATE, StandardOpenOption.READ, StandardOpenOption.WRITE);
-            blobPosition = new AtomicLong(blobs.size());
-        } catch (IOException e) {
-            throw new UncheckedIOException("unable to init blob file: " + file, e);
+        blobChannels = new FileChannel[STRIPES];
+        blobFilePositions = new AtomicLong[STRIPES];
+
+        nextStripe = new AtomicInteger();
+
+        for (int i = 0; i < STRIPES; i++) {
+            Path file = dir.resolve("blobs." + String.valueOf(i));
+            try {
+                FileChannel chan = FileChannel.open(file, StandardOpenOption.CREATE, StandardOpenOption.READ, StandardOpenOption.WRITE);
+                blobFilePositions[i] = new AtomicLong(chan.size());
+                blobChannels[i] = chan;
+            } catch (IOException e) {
+                throw new UncheckedIOException("unable to init or get size of blob file: " + file, e);
+            }
         }
+
     }
 
     public long append(byte[] bytes) {
         int writeSize = bytes.length + 4;
-        final long pos;
-        pos = blobPosition.getAndAdd(writeSize);
+        ByteBuffer intBuf = ThreadLocalByteBuffers.LOCAL_INT_BUFFER.get();
+        intBuf.putInt(bytes.length).flip();
+
+        final int stripe = getNextStripe();
+
+        final long stripePos = blobFilePositions[stripe].getAndAdd(writeSize);
+
         try {
-            ByteBuffer intBuf = ThreadLocalByteBuffers.LOCAL_INT_BUFFER.get();
-            intBuf.putInt(bytes.length).flip();
-
-            blobs.write(ByteBuffer.wrap(Bytes.concat(intBuf.array(), bytes)), pos);
+            int writen = blobChannels[stripe].write(ByteBuffer.wrap(Bytes.concat(intBuf.array(), bytes)), stripePos);
+            if (writen != writeSize) throw new IOException("Bytes written" + writen + "did not equal write size " + writeSize);
         } catch (IOException e) {
-            throw new UncheckedIOException("unable write " + writeSize + " bytes at position " + pos + ": " + file, e);
+            throw new UncheckedIOException("unable write " + writeSize + " bytes @ " + stripePos + " in blob stripe: " + stripe, e);
         }
-        log.trace("appended {} bytes to {} at pos {}", bytes.length, file, pos);
-        return pos;
+
+        if (stripePos > MAX_POSITION) {
+            throw new RuntimeException("Max blob file size exceeded: " + stripePos);
+        }
+
+        byte[] bytePos = Longs.toByteArray(stripePos);
+        bytePos[0] = (byte) stripe;
+        bytePos[1] = log2Ceiling(writeSize);
+
+        log.trace("appended {} bytes to blob stripe file {} @ {}", bytes.length, stripe, stripePos);
+        return Longs.fromByteArray(bytePos);
     }
 
-    public long size(){
-        return blobPosition.get();
+    public long size() {
+        return Arrays.stream(blobFilePositions).mapToLong(AtomicLong::get).sum();
     }
 
-    public byte[] read(long pos) {
-        log.trace("reading from {} @ {}", file, pos);
-        int size = readInt(pos);
-        byte[] buf = new byte[size];
-        read(pos + 4, buf);
-        log.trace("read {} bytes from {} @ {}", size, file, pos);
-        return buf;
+    public byte[] read(long encodedLong) {
+        byte[] longBytes = Longs.toByteArray(encodedLong);
+        log.trace("reading from {} with {}", dir, longBytes);
+
+        int stripe = byteToUnsignedInt(longBytes[0]);
+        int sizeBound = intPowTwo(longBytes[1]);
+
+        long pos = Longs.fromBytes((byte) 0, (byte) 0, longBytes[2], longBytes[3], longBytes[4], longBytes[5], longBytes[6], longBytes[7]);
+
+        byte[] buf = new byte[sizeBound];
+
+        int readSize;
+        try {
+            readSize = blobChannels[stripe].read(ByteBuffer.wrap(buf), pos);
+            if (readSize < 4) throw new IOException("Unable to read at least 4 bytes");
+        } catch (IOException e) {
+            throw new UncheckedIOException("Unable to read " + sizeBound + " bytes from blob stripe " + stripe + " @ " + pos, e);
+        }
+
+        int size = Ints.fromBytes(buf[0], buf[1], buf[2], buf[3]);
+
+        if (readSize < (4 + size)) {
+            throw new RuntimeException("Unable to read correct number of bytes from blob stripe" + stripe + " @ " + pos + ", read " + readSize + " but record " + size + " is greater");
+        }
+
+        final byte[] result = Arrays.copyOfRange(buf, 4, size + 4);
+
+        log.trace("read {} bytes from blob stripe {} @ {}", size, stripe, pos);
+        return result;
     }
 
     public void clear() {
-        log.trace("clearing {}", file);
-        try {
-            blobs.truncate(0);
-            blobPosition.set(0);
-        } catch (IOException e) {
-            throw new UncheckedIOException("unable to clear", e);
+        log.trace("clearing {}", dir);
+
+        for (int i = 0; i < STRIPES; i++) {
+            try {
+                blobFilePositions[i].set(0);
+                blobChannels[i].truncate(0);
+            } catch (IOException e) {
+                throw new UncheckedIOException("unable to clear blob stripe : " + i, e);
+            }
         }
+        nextStripe.set(0);
+       log.trace("clear complete {}", dir);
     }
 
     @Override
     public void close() {
-        log.trace("closing {}", file);
+        log.trace("closing blobs {}", dir);
         closed.set(true);
-        try {
-            blobs.close();
-        } catch (IOException e) {
-            throw new UncheckedIOException("unable to close blobs " + file, e);
+        for (int i = 0; i < STRIPES; i++) {
+            try {
+                blobChannels[i].close();
+            } catch (IOException e) {
+                throw new UncheckedIOException("unable to close blob stripe : " + i, e);
+            }
         }
+        log.trace("closed blobs {}", dir);
     }
 
     @Override
     public void flush() {
-        try {
-            blobs.force(true);
-        } catch (IOException e) {
-            if (closed.get()) {
-                log.debug("Unable to flush closed blobs {}", file, e);
-            } else {
-                throw new UncheckedIOException("unable to flush: " + file, e);
+        log.trace("flushing blobs {}", dir);
+
+        for (int i = 0; i < STRIPES; i++) {
+            try {
+                blobChannels[i].force(true);
+            } catch (IOException e) {
+                if (closed.get()) {
+                    log.debug("Unable to flush closed blobs {}", i, e);
+                } else {
+                    throw new UncheckedIOException("unable to flush blob stripe: " + i, e);
+                }
             }
         }
+        log.trace("flushed blobs {}", dir);
     }
 
-    private int readInt(long pos) {
-        ByteBuffer intBuffer = ThreadLocalByteBuffers.LOCAL_INT_BUFFER.get();
-        read(pos, intBuffer);
-        intBuffer.flip();
-        return intBuffer.getInt();
+    private byte log2Ceiling(int val) {
+        if (val < 1) return 0;
+        double scaledVal = Math.ceil(Math.log(val) / Math.log(2));
+        return (byte) scaledVal;
     }
 
-    private void read(long pos, byte[] buf) {
-        read(pos, ByteBuffer.wrap(buf));
+    private int intPowTwo(byte bval) {
+        double ceilingVal = Math.min(Integer.MAX_VALUE, Math.pow(2, byteToUnsignedInt(bval)));
+        return (int) ceilingVal;
     }
 
-    private void read(long pos, ByteBuffer buf) {
-        int len = buf.remaining();
-        try {
-            blobs.read(buf, pos);
-        } catch (IOException e) {
-            throw new UncheckedIOException("unable to read " + len + " bytes at pos " + pos + " in " + file, e);
-        }
+    private int byteToUnsignedInt(byte bval){
+        int val = 0;
+        val |= bval & 0xFF;
+        return val;
     }
 
-    public static byte[] read(FileChannel chan, long pos) {
-        log.trace("reading @ {}", pos);
-        ByteBuffer intBuffer = ThreadLocalByteBuffers.LOCAL_INT_BUFFER.get();
-        try {
-            chan.read(intBuffer, pos);
-        } catch (IOException e) {
-            throw new UncheckedIOException("unable to read 4 bytes at pos " + pos, e);
-        }
-        intBuffer.flip();
-        int size = intBuffer.getInt();
-        byte[] bytes = new byte[size];
-        ByteBuffer buf = ByteBuffer.wrap(bytes);
-        int len = buf.remaining();
-        try {
-            chan.read(buf, pos + 4);
-        } catch (IOException e) {
-            throw new UncheckedIOException("unable to read " + len + " bytes at pos " + pos, e);
-        }
-        log.trace("read {} bytes @ {}", size, pos);
-        return bytes;
-
+    private int getNextStripe() {
+        return nextStripe.getAndIncrement() & STRIPE_MASK;
     }
 }

--- a/src/test/java/com/upserve/uppend/BlobsTest.java
+++ b/src/test/java/com/upserve/uppend/BlobsTest.java
@@ -30,35 +30,36 @@ public class BlobsTest {
     @Test
     public void testSimple() {
         long pos = blobs.append("foo".getBytes());
-        assertEquals(0, pos);
+        assertEquals(844424930131968L, pos);
         pos = blobs.append("bar".getBytes());
-        assertEquals(7, pos);
-        byte[] bytes = blobs.read(0);
+        assertEquals(72902018968059904L, pos);
+        byte[] bytes = blobs.read(844424930131968L);
         assertEquals("foo", new String(bytes));
-        bytes = blobs.read(7);
+        bytes = blobs.read(72902018968059904L);
         assertEquals("bar", new String(bytes));
     }
 
     @Test
     public void testClear(){
         long pos = blobs.append("foo".getBytes());
-        assertEquals(0, pos);
+        assertEquals(844424930131968L, pos);
         pos = blobs.append("bar".getBytes());
-        assertEquals(7, pos);
+        assertEquals(72902018968059904L, pos);
         blobs.clear();
         pos = blobs.append("baz".getBytes());
-        assertEquals(0, pos);
+        assertEquals(844424930131968L, pos);
     }
 
     @Test
     public void testClose(){
-        assertEquals(0, blobs.append("foo".getBytes()));
+        assertEquals(844424930131968L, blobs.append("foo".getBytes()));
         blobs.close();
         blobs.close();
         blobs = new Blobs(Paths.get("build/test/blobs"));
-        assertEquals("foo", new String(blobs.read(0)));
+        assertEquals("foo", new String(blobs.read(844424930131968L)));
     }
 
+    @Ignore
     @Test(expected = UncheckedIOException.class)
     public void testCloseException() throws Exception {
         resetFinal(blobs, "blobs", new FileChannel() {


### PR DESCRIPTION
@bfulton Please review

Stripe blob writes across 256 files.
Encode the file number and an upper bound for the size in the long 'position' returned by the blob store. 
This allows both the read and write to be a single operation on the file channel.

Observed performance gains:
2018-02-15 10:45:29,468 INFO [Thread-3:{}] com.upserve.uppend.cli.benchmark.Benchmark Read:  808.61mb/s    266r/s; Write    0.00mb/s      0a/s; Mem  276.32mb free  358.00mb total

Vs Beta branch:
2018-02-15 10:35:54,176 INFO [Thread-3:{}] com.upserve.uppend.cli.benchmark.Benchmark Read:  412.47mb/s    134r/s; Write    0.00mb/s      0a/s; Mem  131.14mb free  228.50mb total


Interestingly, it takes a while for the benchmark to get up to speed. I am not sure why that is. It is significantly longer with the striped blobs. I would guess this is the JVM optimizer?