### PR TITLE
Handle symlinks

### DIFF
--- a/src/main/java/com/upserve/uppend/FileStore.java
+++ b/src/main/java/com/upserve/uppend/FileStore.java
@@ -44,7 +44,7 @@ abstract class FileStore<T> implements AutoCloseable, RegisteredFlushable, Trimm
         }
         this.dir = dir;
         try {
-            Files.createDirectories((Files.isSymbolicLink(dir) ? Files.readSymbolicLink(dir) : dir).toRealPath());
+            Files.createDirectories((Files.isSymbolicLink(dir) ? Files.readSymbolicLink(dir).toRealPath() : dir));
         } catch (IOException e) {
             throw new UncheckedIOException("unable to mkdirs: " + dir, e);
         }

--- a/src/main/java/com/upserve/uppend/FileStore.java
+++ b/src/main/java/com/upserve/uppend/FileStore.java
@@ -44,7 +44,7 @@ abstract class FileStore<T> implements AutoCloseable, RegisteredFlushable, Trimm
         }
         this.dir = dir;
         try {
-            Files.createDirectories(dir);
+            Files.createDirectories((Files.isSymbolicLink(dir) ? Files.readSymbolicLink(dir) : dir).toRealPath());
         } catch (IOException e) {
             throw new UncheckedIOException("unable to mkdirs: " + dir, e);
         }

--- a/src/main/java/com/upserve/uppend/util/SafeDeleting.java
+++ b/src/main/java/com/upserve/uppend/util/SafeDeleting.java
@@ -17,7 +17,7 @@ public class SafeDeleting {
             return;
         }
         AtomicReference<IOException> errorRef = new AtomicReference<>();
-        Files.walk(path, FileVisitOption.FOLLOW_LINKS)
+        Files.walk(path)
                 .sorted(Comparator.reverseOrder())
                 .forEach(p -> {
                     if (errorRef.get() != null) {


### PR DESCRIPTION
Allow Symbolic Links in the directory structure leading to an Uppend Store.
According to the docs [readSymbolicLink](https://docs.oracle.com/javase/7/docs/api/java/nio/file/Files.html#readSymbolicLink(java.nio.file.Path)) works uniformly for soft links hard links and links across file systems.
We should confirm behavior in nix environment.