### PR TITLE
Buffered append store

### DIFF
--- a/src/main/java/com/upserve/uppend/BufferedAppendOnlyStore.java
+++ b/src/main/java/com/upserve/uppend/BufferedAppendOnlyStore.java
@@ -1,0 +1,60 @@
+package com.upserve.uppend;
+
+import com.upserve.uppend.lookup.*;
+import org.slf4j.Logger;
+
+import java.lang.invoke.MethodHandles;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+
+/**
+ * The Buffered Append Only Store is optimized for random writes to the partition and key with fixed memory use at the
+ * expense of durability and latency. No guarantee is made about when an append operation will be durably persisted or available
+ * to read. The application must successfully call flush or close to persist the appended values.
+ *
+ * By default the provided buffer size is a suggestion. The buffer is actually flushed based on the number of entries
+ * with entropy in a range equal the the suggested size divided by 5.
+ */
+public class BufferedAppendOnlyStore extends FileAppendOnlyStore {
+    private static final Logger log = org.slf4j.LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+    private final LookupAppendBuffer lookupAppendBuffer;
+
+    BufferedAppendOnlyStore(Path dir, boolean doLock, int longLookupHashSize, int bufferSize, int blobsPerBlock, ExecutorService executorService) {
+        super(dir, 0, doLock, longLookupHashSize, 0, blobsPerBlock);
+        lookupAppendBuffer = new LookupAppendBuffer(lookups, blocks, bufferSize, bufferSize/5, executorService);
+    }
+
+    @Override
+    public void append(String partition, String key, byte[] value) {
+        log.trace("buffered append for key '{}'", key);
+        long blobPos = blobs.append(value);
+        lookupAppendBuffer.bufferedAppend(partition, key, blobPos);
+    }
+
+    @Override
+    public void trim() {
+        lookupAppendBuffer.flush();
+        super.trim();
+    }
+
+    @Override
+    protected void flushInternal() {
+        lookupAppendBuffer.flush();
+        super.flushInternal();
+    }
+
+    @Override
+    protected void closeInternal() {
+        lookupAppendBuffer.close();
+        super.closeInternal();
+    }
+
+    @Override
+    public void clear(){
+        lookupAppendBuffer.clearLock();
+        super.clear();
+        lookupAppendBuffer.unlock();
+    }
+}

--- a/src/main/java/com/upserve/uppend/FileAppendOnlyStore.java
+++ b/src/main/java/com/upserve/uppend/FileAppendOnlyStore.java
@@ -13,13 +13,13 @@ import java.util.stream.*;
 public class FileAppendOnlyStore extends FileStore implements AppendOnlyStore {
     private static final Logger log = org.slf4j.LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-    private static final int NUM_BLOBS_PER_BLOCK = 127;
+    protected static final int DEFAULT_BLOBS_PER_BLOCK = 127;
 
-    private final LongLookup lookups;
-    private final BlockedLongs blocks;
-    private final Blobs blobs;
+    protected final LongLookup lookups;
+    protected final BlockedLongs blocks;
+    protected final Blobs blobs;
 
-    FileAppendOnlyStore(Path dir, int flushDelaySeconds, boolean doLock, int longLookupHashSize, int longLookupWriteCacheSize) {
+    FileAppendOnlyStore(Path dir, int flushDelaySeconds, boolean doLock, int longLookupHashSize, int longLookupWriteCacheSize, int blobsPerBlock) {
         super(dir, flushDelaySeconds, doLock);
 
         lookups = new LongLookup(
@@ -27,7 +27,7 @@ public class FileAppendOnlyStore extends FileStore implements AppendOnlyStore {
                 longLookupHashSize,
                 longLookupWriteCacheSize
         );
-        blocks = new BlockedLongs(dir.resolve("blocks"), NUM_BLOBS_PER_BLOCK);
+        blocks = new BlockedLongs(dir.resolve("blocks"), blobsPerBlock);
         blobs = new Blobs(dir.resolve("blobs"));
     }
 

--- a/src/main/java/com/upserve/uppend/cli/CommandBenchmark.java
+++ b/src/main/java/com/upserve/uppend/cli/CommandBenchmark.java
@@ -39,6 +39,9 @@ public class CommandBenchmark implements Callable<Void> {
     @Option(names = {"-c", "--cache-size"}, description = "Cache size")
     int cacheSize = LongLookup.DEFAULT_WRITE_CACHE_SIZE;
 
+    @Option(names = {"-b", "--buffered"}, description = "Use BufferedAppendOnlyStore with this size")
+    int buffered = 0;
+
     @Option(names = {"-f", "--flush-delay"}, description = "Flush delay (sec)")
     int flushDelay = FileAppendOnlyStore.DEFAULT_FLUSH_DELAY_SECONDS;
 
@@ -48,7 +51,7 @@ public class CommandBenchmark implements Callable<Void> {
 
     @Override
     public Void call() throws Exception {
-        Benchmark benchmark = new Benchmark(mode, path, maxPartitions, maxKeys, count, hashSize, cacheSize, flushDelay);
+        Benchmark benchmark = new Benchmark(mode, path, maxPartitions, maxKeys, count, hashSize, cacheSize, flushDelay, buffered);
         benchmark.run();
         return null;
     }

--- a/src/main/java/com/upserve/uppend/lookup/LongLookup.java
+++ b/src/main/java/com/upserve/uppend/lookup/LongLookup.java
@@ -319,7 +319,7 @@ public class LongLookup implements AutoCloseable, Flushable {
         }
     }
 
-    private Path hashPath(String partition, LookupKey key) {
+    protected Path hashPath(String partition, LookupKey key) {
         String hashPath = hashFunction == null ? "00" : hashPath(hashFunction.hashBytes(key.bytes()));
         return dir.resolve(partition).resolve(hashPath);
     }

--- a/src/main/java/com/upserve/uppend/lookup/LookupAppendBuffer.java
+++ b/src/main/java/com/upserve/uppend/lookup/LookupAppendBuffer.java
@@ -1,0 +1,192 @@
+package com.upserve.uppend.lookup;
+
+import com.google.common.collect.*;
+import com.google.common.util.concurrent.Striped;
+import com.upserve.uppend.BlockedLongs;
+import org.slf4j.Logger;
+
+import java.io.*;
+import java.lang.invoke.MethodHandles;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.*;
+import java.util.concurrent.locks.Lock;
+import java.util.stream.Collectors;
+
+/**
+ * A buffered Lookup Writer for memory efficient writes to random hashPaths in the append only store.
+ * This buffer maintains a high throughput with fixed memory use by sacrificing guaranteed durability. The application
+ * must successfully flush the append store before an append is guaranteed to be written.
+ */
+public class LookupAppendBuffer {
+    private static final Logger log = org.slf4j.LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+    private static final int MIN_BUFFER_SIZE = 20;
+
+    private final int maxSize;
+    private final int minSize;
+    private final LongLookup longLookup;
+    private final BlockedLongs blockedLongs;
+    private final ConcurrentHashMap<Path, List<Map.Entry<LookupKey, Long>>> appendBuffer;
+
+    private final Striped<Lock> pathLock;
+
+    private final ExecutorService threadPool;
+    private final boolean myThreadPool;
+
+    private final AtomicInteger taskCount = new AtomicInteger();
+    private AtomicBoolean closed = new AtomicBoolean(false);
+
+    public LookupAppendBuffer(LongLookup longLookup, BlockedLongs blockedLongs, int bufferMax, int buffRange, ExecutorService threadPool) {
+        if (bufferMax < MIN_BUFFER_SIZE)
+            throw new IllegalArgumentException(String.format("Invalid buffer size %s is less than %s", bufferMax, MIN_BUFFER_SIZE));
+        this.longLookup = longLookup;
+        this.blockedLongs = blockedLongs;
+        this.appendBuffer = new ConcurrentHashMap<>(); // How to set initial Capacity, load and concurrency? It has a huge performance impact
+
+        this.pathLock = Striped.lock(10007);
+
+        this.minSize = bufferMax;
+        this.maxSize = bufferMax + buffRange + 1;
+        if (threadPool == null) {
+            this.threadPool = Executors.newFixedThreadPool(4);
+            this.myThreadPool = true;
+        } else {
+            this.threadPool = threadPool;
+            this.myThreadPool = false;
+        }
+    }
+
+
+    /**
+     * Add a blob position for a partition and key the the buffered Map. If the number of entries for that hashPath
+     * exceeds the bufferSize then submit a task to flush that entry.
+     *
+     * @param partition the append store partition
+     * @param key       the append store key
+     * @param blobPos   the position of the bytes in the blob file
+     */
+    public void bufferedAppend(String partition, String key, long blobPos) {
+        LookupKey lookupKey = new LookupKey(key);
+
+        // ConcurrentHashMap guarantees atomic, blocking exactly once execution of the compute method.
+        appendBuffer.compute(longLookup.hashPath(partition, lookupKey), (Path pathKey, List<Map.Entry<LookupKey, Long>> entryList) -> {
+            if (entryList == null) {
+                entryList = new ArrayList<>(maxSize);
+            }
+
+            if (closed.get()) throw new RuntimeException("Closed for business");
+
+            entryList.add(Maps.immutableEntry(lookupKey, blobPos));
+
+            if (entryList.size() >= ThreadLocalRandom.current().nextInt(minSize, maxSize)) {
+                List<Map.Entry<LookupKey, Long>> finalEntryList = new ArrayList<>(entryList);
+                entryList.clear();
+                threadPool.submit(() -> flushEntry(pathKey, finalEntryList));
+                taskCount.getAndAdd(1);
+            }
+            return entryList;
+        });
+    }
+
+    /**
+     * Returns the size of the buffer Map. Note that entries are never removed so the map will grow to the size of
+     * the hash space and never shrink. This is not the number of appends currently buffered.
+     *
+     * @return the number of entries in the buffer Map.
+     */
+    public int bufferCount() {
+        return appendBuffer.size();
+    }
+
+    public long bufferEntries() {
+        return appendBuffer.entrySet().stream().mapToLong(entry -> entry.getValue().size()).sum();
+    }
+
+    /**
+     * For occasional inspection of how busy the flusher is.
+     *
+     * @return the size of the task queue
+     */
+    public int taskCount() {
+        return taskCount.get();
+    }
+
+    public void flush() {
+        List<Future> tasks = appendBuffer
+                .keySet()
+                .stream()
+                .parallel()
+                .map(path -> {
+                    final Future[] future = new Future[1];
+                    appendBuffer.compute(path, (keyPath, entryList) -> {
+                        if (entryList.isEmpty()) return entryList;
+                        List<Map.Entry<LookupKey, Long>> finalEntryList = new ArrayList<>(entryList);
+                        entryList.clear();
+                        future[0] = threadPool.submit(() -> flushEntry(path, finalEntryList));
+                        taskCount.addAndGet(1);
+                        return entryList;
+                    });
+                    return future[0];
+                })
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+
+        // Ensure that all the tasks currently in the queue finish before returning
+        tasks.forEach(f -> {
+            try {
+                f.get();
+            } catch (InterruptedException e) {
+                log.error("Buffered Append task interrupted", e);
+            } catch (ExecutionException e) {
+                log.error("Buffered Append exception", e);
+            }
+        });
+    }
+
+    public void close() {
+        if (closed.getAndSet(true)) return;
+        flush();
+        if (myThreadPool) {
+            threadPool.shutdown();
+            try {
+                boolean result = threadPool.awaitTermination(20_000, TimeUnit.MILLISECONDS);
+                if (result) {
+                    log.debug("flushed the buffer and closed the thread pool!");
+                } else {
+                    log.error("Close timed out waiting for tasks to finish");
+                }
+            } catch (InterruptedException e) {
+                log.error("close interrupted!", e);
+            }
+        }
+    }
+
+    private void flushEntry(Path path, List<Map.Entry<LookupKey, Long>> entryList) {
+        Lock lock = pathLock.get(path);
+        lock.lock();
+
+        try (LookupData lookupData = new LookupData(path.resolve("data"), path.resolve("meta"))) {
+            entryList.forEach(entry -> {
+                long blockPos = lookupData.putIfNotExists(entry.getKey(), blockedLongs::allocate);
+                blockedLongs.append(blockPos, entry.getValue());
+            });
+            taskCount.getAndAdd(-1);
+        } catch (IOException e) {
+            log.error("Could not close lookupData: {}", path);
+        } finally {
+            lock.unlock();
+        }
+
+    }
+
+    public void clearLock() {
+        closed.set(true);
+        flush();
+    }
+
+    public void unlock() {
+        closed.set(false);
+    }
+}

--- a/src/test/java/com/upserve/uppend/AppendOnlyStoreBuilderTest.java
+++ b/src/test/java/com/upserve/uppend/AppendOnlyStoreBuilderTest.java
@@ -15,7 +15,7 @@ public class AppendOnlyStoreBuilderTest {
         Path path = Paths.get("build/tmp/test/append-only-store-builder");
         SafeDeleting.removeDirectory(path);
         MetricRegistry metrics = new MetricRegistry();
-        AppendOnlyStore store = Uppend.store(path).withMetrics(metrics).build();
+        AppendOnlyStore store = Uppend.store(path).withMetrics(metrics).build(false);
         store.flush();
         assertEquals(1, metrics.getTimers().get(AppendOnlyStoreWithMetrics.FLUSH_TIMER_METRIC_NAME).getCount());
     }

--- a/src/test/java/com/upserve/uppend/AppendOnlyStoreTest.java
+++ b/src/test/java/com/upserve/uppend/AppendOnlyStoreTest.java
@@ -16,7 +16,7 @@ import static org.junit.Assert.*;
 
 public class AppendOnlyStoreTest {
     private AppendOnlyStore newStore() {
-        return new AppendOnlyStoreBuilder().withDir(Paths.get("build/test/file-append-only-store")).withLongLookupHashSize(8).build();
+        return new AppendOnlyStoreBuilder().withDir(Paths.get("build/test/file-append-only-store")).withLongLookupHashSize(8).build(false);
     }
 
     private AppendOnlyStore store;

--- a/src/test/java/com/upserve/uppend/DocExamplesTests.java
+++ b/src/test/java/com/upserve/uppend/DocExamplesTests.java
@@ -25,7 +25,7 @@ public class DocExamplesTests {
         SafeDeleting.removeTempPath(Paths.get("build/tmp-db"));
 
         // *** START SNIPPET ***
-        AppendOnlyStore db = Uppend.store("build/tmp-db").build();
+        AppendOnlyStore db = Uppend.store("build/tmp-db").build(false);
 
         db.append("my-partition", "my-key", "value-1".getBytes());
         db.append("my-partition", "my-key", "value-2".getBytes());

--- a/src/test/java/com/upserve/uppend/LongLookupPerformanceTest.java
+++ b/src/test/java/com/upserve/uppend/LongLookupPerformanceTest.java
@@ -20,7 +20,7 @@ public class LongLookupPerformanceTest {
         SafeDeleting.removeTempPath(lookupDir);
 
         LongLookup lookup;
-        lookup = new LongLookup(lookupDir);
+        lookup = new LongLookup(lookupDir, 512, 512);
         long lastReportTime = System.currentTimeMillis();
         log.info("init: starting");
         for(int i = 0; i < INITIAL_KEYS; ++i) {

--- a/src/test/java/com/upserve/uppend/UppendTest.java
+++ b/src/test/java/com/upserve/uppend/UppendTest.java
@@ -20,7 +20,7 @@ public class UppendTest {
         final Path path = Paths.get(pathStr);
         SafeDeleting.removeTempPath(path);
         assertFalse(Files.exists(path));
-        AppendOnlyStore store = Uppend.store(pathStr).build();
+        AppendOnlyStore store = Uppend.store(pathStr).build(false);
         store.append("partition", "foo", "bar".getBytes());
         assertTrue(Files.exists(path));
         store.flush();

--- a/src/test/java/com/upserve/uppend/lookup/LookupAppendBufferTest.java
+++ b/src/test/java/com/upserve/uppend/lookup/LookupAppendBufferTest.java
@@ -1,0 +1,142 @@
+package com.upserve.uppend.lookup;
+
+import com.upserve.uppend.*;
+import com.upserve.uppend.util.SafeDeleting;
+import org.junit.*;
+
+import java.io.IOException;
+import java.nio.file.*;
+import java.util.Optional;
+import java.util.concurrent.*;
+import java.util.stream.IntStream;
+
+import static org.junit.Assert.*;
+
+public class LookupAppendBufferTest {
+    private final Path path = Paths.get("build/test/long-lookup-test");
+
+    private LookupAppendBuffer instance;
+    private LongLookup longLookup;
+    private BlockedLongs blockedLongs;
+
+    @Before
+    public void init() throws IOException {
+        SafeDeleting.removeDirectory(path);
+
+        longLookup = new LongLookup(path, 32, 0);
+        blockedLongs = new BlockedLongs(path.resolve("blocks"), 127);
+
+        instance = new LookupAppendBuffer(longLookup, blockedLongs, 24, 0, null);
+    }
+
+    @After
+    public void cleanup() throws Exception {
+        instance.close();
+        longLookup.close();
+        blockedLongs.close();
+        SafeDeleting.removeDirectory(path);
+    }
+
+    @Test
+    public void testAppend() throws InterruptedException, ExecutionException {
+        instance.bufferedAppend("partition1", "key", 15);
+        assertEquals(1, instance.bufferCount());
+
+        instance.bufferedAppend("partition1", "key", 72);
+        assertEquals(1, instance.bufferCount());
+
+        instance.bufferedAppend("partition2", "key", 16);
+        assertEquals(2, instance.bufferCount());
+
+        instance.flush();
+
+        long lookup;
+        lookup = longLookup.get("partition1","key");
+        assertArrayEquals(new long[]{15, 72}, blockedLongs.values(lookup).toArray());
+
+        instance.bufferedAppend("partition2", "key", 29);
+        assertEquals(2, instance.bufferCount());
+
+        // New data is not yet written
+        lookup = longLookup.get("partition2","key");
+        assertArrayEquals(new long[]{16}, blockedLongs.values(lookup).toArray());
+    }
+
+    @Test
+    public void fixedSizeFlush() throws ExecutionException, InterruptedException {
+        // Test a hot key flushing many times
+        IntStream.range(0, 24*50)
+                .forEach(val -> instance.bufferedAppend("partition3", "key", val));
+
+        while (instance.taskCount() > 0) {
+            Thread.sleep(10);
+        }
+
+        long lookup = longLookup.get("partition3","key");
+        assertEquals(24*50, blockedLongs.values(lookup).count());
+    }
+
+    @Test
+    public void testClose(){
+        instance.bufferedAppend("partition1", "key", 15);
+        assertEquals(1, instance.bufferCount());
+
+        instance.bufferedAppend("partition1", "key", 72);
+        assertEquals(1, instance.bufferCount());
+
+        instance.bufferedAppend("partition2", "key", 16);
+        assertEquals(2, instance.bufferCount());
+
+        instance.close();
+
+        long lookup;
+        lookup = longLookup.get("partition1","key");
+        assertArrayEquals(new long[]{15, 72}, blockedLongs.values(lookup).toArray());
+
+        lookup = longLookup.get("partition2","key");
+        assertArrayEquals(new long[]{16}, blockedLongs.values(lookup).toArray());
+
+
+        Exception expected = null;
+        try {
+            instance.bufferedAppend("partition2", "key", 16);
+        } catch (RuntimeException e) {
+            expected = e;
+        }
+        assertNotNull("Should have failed to write to a closed buffered appender",expected);
+    }
+
+
+    @Test
+    public void testClear(){
+        instance.bufferedAppend("partition1", "key", 15);
+        assertEquals(1, instance.bufferCount());
+
+        instance.flush();
+        long lookup;
+        lookup = longLookup.get("partition1","key");
+        assertArrayEquals(new long[]{15}, blockedLongs.values(lookup).toArray());
+
+        instance.clearLock();
+        Exception expected = null;
+        try {
+            instance.bufferedAppend("partition1", "key", 15);
+        }catch (RuntimeException e) {
+            expected = e;
+        }
+        assertNotNull("Should have failed to write to a closed buffered appender", expected);
+
+        blockedLongs.clear();
+        longLookup.clear();
+        instance.unlock();
+
+        assertEquals(-1, longLookup.get("partition1","key"));
+
+        instance.bufferedAppend("partition1", "key", 16);
+        assertEquals(1, instance.bufferCount());
+
+        instance.flush();
+        lookup = longLookup.get("partition1","key");
+        assertArrayEquals(new long[]{16}, blockedLongs.values(lookup).toArray());
+    }
+}


### PR DESCRIPTION
The Buffered Append Store should be used when there is no natural hot write partition. It provides a configurable finite memory buffer where writes to each partition and hash path are stored till they can be written efficiently as a group. There is no bound on when the buffer will be flushed to disk for a particular write making it available to read. 

Think of this as a tool for use in a batch process that needs high write throughput for random keys, but does not need to read its writes.

Changes:
* Add a Buffered Append Store class
* Add LookupAppendBuffer class
* Add configurable Block Size
* Add read only option in AppendOnlyStoreBuilder
* Update Benchmark
