### PR TITLE
Cache reads from blobs and lookups

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,7 @@ repositories {
 
 dependencies {
     compile 'com.google.guava:guava:21.0'
+    compile 'com.github.ben-manes.caffeine:caffeine:2.3.5'
     compile 'info.picocli:picocli:2.0.1'
     compile 'io.dropwizard.metrics:metrics-core:3.2.3'
     compile 'it.unimi.dsi:fastutil:7.0.13'

--- a/src/main/java/com/upserve/uppend/BufferedAppendOnlyStore.java
+++ b/src/main/java/com/upserve/uppend/BufferedAppendOnlyStore.java
@@ -23,14 +23,14 @@ public class BufferedAppendOnlyStore extends FileAppendOnlyStore {
 
     BufferedAppendOnlyStore(Path dir, boolean doLock, int longLookupHashSize, int bufferSize, int blobsPerBlock, ExecutorService executorService) {
         super(dir, 0, doLock, longLookupHashSize, 0, blobsPerBlock);
-        lookupAppendBuffer = new LookupAppendBuffer(lookups, blocks, bufferSize, bufferSize/5, executorService);
+        lookupAppendBuffer = new LookupAppendBuffer(new LongLookup(dir, new LookupCache()), blocks, bufferSize, bufferSize/5, executorService);
     }
 
     @Override
     public void append(String partition, String key, byte[] value) {
         log.trace("buffered append for key '{}'", key);
-        long blobPos = blobs.append(value);
-        lookupAppendBuffer.bufferedAppend(partition, key, blobPos);
+//        long blobPos = blobs.append(value);
+//        lookupAppendBuffer.bufferedAppend(partition, key, blobPos);
     }
 
     @Override

--- a/src/main/java/com/upserve/uppend/FileCounterStore.java
+++ b/src/main/java/com/upserve/uppend/FileCounterStore.java
@@ -1,6 +1,6 @@
 package com.upserve.uppend;
 
-import com.upserve.uppend.lookup.LongLookup;
+import com.upserve.uppend.lookup.*;
 import org.slf4j.Logger;
 
 import java.lang.invoke.MethodHandles;
@@ -18,6 +18,7 @@ public class FileCounterStore extends FileStore implements CounterStore {
 
         lookup = new LongLookup(
                 dir.resolve("inc-lookup"),
+                new LookupCache(),
                 longLookupHashSize,
                 longLookupWriteCacheSize
         );

--- a/src/main/java/com/upserve/uppend/Partition.java
+++ b/src/main/java/com/upserve/uppend/Partition.java
@@ -1,0 +1,57 @@
+package com.upserve.uppend;
+
+import com.upserve.uppend.blobs.*;
+import com.upserve.uppend.lookup.*;
+
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.stream.Stream;
+
+public class Partition {
+
+    private final LongLookup lookups;
+    private final Blobs blobs;
+
+
+    public Partition(Path partitionPath, PagedFileMapper pagedFileMapper, LongLookup longLookup){
+        this.lookups = longLookup;
+        blobs = new Blobs(partitionPath, pagedFileMapper);
+    }
+
+    void append(String key, byte[] blob, BlockedLongs blocks){
+
+    }
+
+    Stream<byte[]> read(String key, BlockedLongs blocks){
+
+        return Stream.empty();
+    }
+    //TODO add other read methods flushed, sequential
+
+    Stream<Map.Entry<String, Stream<Byte[]>>> scan(BlockedLongs blocks){
+        return Stream.empty();
+    }
+
+
+    void scan(BlockedLongs blocks, BiConsumer<String, Stream<byte[]>> callback){
+
+    }
+
+    void flush(){
+
+    }
+
+    void close(){
+
+    }
+
+    void trim(){
+
+    }
+
+    void clear(){
+
+    }
+
+}

--- a/src/main/java/com/upserve/uppend/blobs/FilePage.java
+++ b/src/main/java/com/upserve/uppend/blobs/FilePage.java
@@ -1,0 +1,82 @@
+package com.upserve.uppend.blobs;
+
+import java.io.*;
+import java.nio.*;
+import java.nio.channels.FileChannel;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class FilePage {
+
+    private final byte[] bytes;
+    private final PageKey key;
+    private final int pageSize;
+
+    private int bytesRead;
+
+    public FilePage(PageKey key, int pageSize) throws IOException {
+        this.key = key;
+        this.pageSize = pageSize;
+        this.bytes = new byte[pageSize];
+        loadBytes();
+    }
+
+    protected int get(long filePosition, byte[] dst, int bufferOffset) throws IOException {
+        int result = getBytes(filePosition, dst, bufferOffset);
+        if (result > 0) return result;
+
+        loadMore();
+        result =  getBytes(filePosition, dst, bufferOffset);
+        if (result > 0) return result;
+
+        throw new IOException("Unable to read " + (dst.length - bufferOffset) + " bytes at pos " + filePosition + ": Past end of file: " + key.getFileName());
+    }
+
+    private int pagePosition(long pos){
+        return (int) (pos % (long) pageSize);
+    }
+
+    private int getBytes(long filePosition, byte[] dst, int bufferOffset) throws IOException {
+        final int pagePos = pagePosition(filePosition);
+        final int desiredRead = dst.length - bufferOffset;
+        final int availableToRead = bytesRead - pagePos;
+
+        final int actualRead;
+        if (availableToRead >= desiredRead) {
+            actualRead = desiredRead;
+        } else if (bytesRead == pageSize){
+            // Read to end of page
+            actualRead = availableToRead;
+        } else {
+            return -1;
+        }
+
+        try {
+            System.arraycopy(bytes,
+                    pagePos,
+                    dst,
+                    bufferOffset,
+                    actualRead);
+        } catch (RuntimeException e) {
+            throw new IOException("Unable to read " + desiredRead + " bytes from page " + key.getPage() + " at pos " + filePosition + " in file " + key.getFileName(), e);
+        }
+        return actualRead;
+    }
+
+    private void loadMore() throws IOException {
+        synchronized (this) {
+            if (bytesRead < pageSize){
+                loadBytes();
+            }
+        }
+    }
+
+    private void loadBytes() throws IOException {
+        long pos = (long) key.getPage() * pageSize + bytesRead;
+        ByteBuffer buffer = ByteBuffer.wrap(bytes, bytesRead, pageSize - bytesRead);
+        try {
+            bytesRead += key.getChan().read(buffer, pos);
+        } catch (IOException e) {
+            throw new IOException("Unable to read page " + key.getPage() + " at pos " + pos + " with Size " + pageSize + " in file " + key.getFileName(), e);
+        }
+    }
+}

--- a/src/main/java/com/upserve/uppend/blobs/PageKey.java
+++ b/src/main/java/com/upserve/uppend/blobs/PageKey.java
@@ -1,0 +1,43 @@
+package com.upserve.uppend.blobs;
+
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.util.Objects;
+
+public class PageKey {
+    private final Path fileName;
+    private final FileChannel chan;
+    private final int page;
+
+    PageKey(Path fileName, FileChannel chan, int page){
+        this.fileName = fileName;
+        this.chan = chan;
+        this.page = page;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PageKey pageKey = (PageKey) o;
+        return page == pageKey.page &&
+                Objects.equals(chan, pageKey.chan);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(chan, page);
+    }
+
+    Path getFileName() {
+        return fileName;
+    }
+
+    FileChannel getChan() {
+        return chan;
+    }
+
+    int getPage() {
+        return page;
+    }
+}

--- a/src/main/java/com/upserve/uppend/blobs/PagedFileMapper.java
+++ b/src/main/java/com/upserve/uppend/blobs/PagedFileMapper.java
@@ -1,0 +1,47 @@
+package com.upserve.uppend.blobs;
+
+import com.github.benmanes.caffeine.cache.*;
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
+
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+
+public class PagedFileMapper {
+
+    private final int pageSize;
+
+    private final LoadingCache<PageKey, FilePage> pageCache;
+
+    public PagedFileMapper(int pageSize) {
+        this.pageSize = pageSize;
+
+        this.pageCache = Caffeine
+                .<PageKey, FilePage>newBuilder()
+                .initialCapacity(1000)
+                .<PageKey, FilePage>build(key -> new FilePage(key, pageSize));
+    }
+
+    FilePage getPage(FileChannel chan, Path file, long pos){
+        return getPage(new PageKey(file, chan, page(pos)));
+    }
+
+    private FilePage getPage(PageKey key){
+        return pageCache.get(key);
+    }
+
+    private int page(long pos) {
+        long pageIndexLong = pos / pageSize;
+        if (pageIndexLong > Integer.MAX_VALUE) {
+            throw new RuntimeException("page index exceeded max int: " + pageIndexLong);
+        }
+        return (int) pageIndexLong;
+    }
+
+    public CacheStats cacheStats(){
+        return pageCache.stats();
+    }
+
+    int getPageSize() {
+        return pageSize;
+    }
+}

--- a/src/main/java/com/upserve/uppend/lookup/LongLookup.java
+++ b/src/main/java/com/upserve/uppend/lookup/LongLookup.java
@@ -42,11 +42,13 @@ public class LongLookup implements AutoCloseable, Flushable {
     private final LinkedHashMap<Path, LookupData> writeCache;
     private final Object writeCacheDataCloseMonitor = new Object();
 
-    public LongLookup(Path dir) {
-        this(dir, DEFAULT_HASH_SIZE, DEFAULT_WRITE_CACHE_SIZE);
+    private final LookupCache lookupCache;
+
+    public LongLookup(Path dir, LookupCache lookupCache) {
+        this(dir, lookupCache, DEFAULT_HASH_SIZE, DEFAULT_WRITE_CACHE_SIZE);
     }
 
-    public LongLookup(Path dir, int hashSize, int writeCacheSize) {
+    public LongLookup(Path dir, LookupCache lookupCache, int hashSize, int writeCacheSize) {
         if (hashSize < 1) {
             throw new IllegalArgumentException("hashSize must be >= 1");
         }
@@ -58,6 +60,8 @@ public class LongLookup implements AutoCloseable, Flushable {
         }
 
         this.dir = dir;
+        this.lookupCache = lookupCache;
+
         try {
             Files.createDirectories(dir);
         } catch (IOException e) {

--- a/src/main/java/com/upserve/uppend/lookup/LookupCache.java
+++ b/src/main/java/com/upserve/uppend/lookup/LookupCache.java
@@ -1,0 +1,4 @@
+package com.upserve.uppend.lookup;
+
+public class LookupCache {
+}

--- a/src/test/java/com/upserve/uppend/BlobsTest.java
+++ b/src/test/java/com/upserve/uppend/BlobsTest.java
@@ -1,5 +1,6 @@
 package com.upserve.uppend;
 
+import com.upserve.uppend.blobs.*;
 import com.upserve.uppend.util.SafeDeleting;
 import org.junit.*;
 
@@ -15,9 +16,11 @@ import static org.junit.Assert.assertEquals;
 public class BlobsTest {
     private Blobs blobs;
 
+    private PagedFileMapper pagedFileMapper = new PagedFileMapper(32);
+
     @Before
     public void initialize() {
-        blobs = new Blobs(Paths.get("build/test/blobs"));
+        blobs = new Blobs(Paths.get("build/test/blobs"), pagedFileMapper);
         blobs.clear();
     }
 
@@ -55,7 +58,7 @@ public class BlobsTest {
         assertEquals(0, blobs.append("foo".getBytes()));
         blobs.close();
         blobs.close();
-        blobs = new Blobs(Paths.get("build/test/blobs"));
+        blobs = new Blobs(Paths.get("build/test/blobs"), pagedFileMapper);
         assertEquals("foo", new String(blobs.read(0)));
     }
 

--- a/src/test/java/com/upserve/uppend/LongLookupPerformanceTest.java
+++ b/src/test/java/com/upserve/uppend/LongLookupPerformanceTest.java
@@ -1,6 +1,6 @@
 package com.upserve.uppend;
 
-import com.upserve.uppend.lookup.LongLookup;
+import com.upserve.uppend.lookup.*;
 import com.upserve.uppend.util.SafeDeleting;
 import org.junit.*;
 import org.slf4j.Logger;
@@ -20,7 +20,7 @@ public class LongLookupPerformanceTest {
         SafeDeleting.removeTempPath(lookupDir);
 
         LongLookup lookup;
-        lookup = new LongLookup(lookupDir, 512, 512);
+        lookup = new LongLookup(lookupDir, new LookupCache(), 512, 512);
         long lastReportTime = System.currentTimeMillis();
         log.info("init: starting");
         for(int i = 0; i < INITIAL_KEYS; ++i) {
@@ -40,7 +40,7 @@ public class LongLookupPerformanceTest {
 
     @Test(timeout = 100)
     public void speedTest() throws Exception {
-        LongLookup lookup = new LongLookup(lookupDir);
+        LongLookup lookup = new LongLookup(lookupDir, new LookupCache());
         lookup.close();
     }
 

--- a/src/test/java/com/upserve/uppend/lookup/LookupAppendBufferTest.java
+++ b/src/test/java/com/upserve/uppend/lookup/LookupAppendBufferTest.java
@@ -15,6 +15,7 @@ import static org.junit.Assert.*;
 public class LookupAppendBufferTest {
     private final Path path = Paths.get("build/test/long-lookup-test");
 
+    private final LookupCache lookupCache = new LookupCache();
     private LookupAppendBuffer instance;
     private LongLookup longLookup;
     private BlockedLongs blockedLongs;
@@ -23,7 +24,7 @@ public class LookupAppendBufferTest {
     public void init() throws IOException {
         SafeDeleting.removeDirectory(path);
 
-        longLookup = new LongLookup(path, 32, 0);
+        longLookup = new LongLookup(path, lookupCache, 32, 0);
         blockedLongs = new BlockedLongs(path.resolve("blocks"), 127);
 
         instance = new LookupAppendBuffer(longLookup, blockedLongs, 24, 0, null);


### PR DESCRIPTION
Work in progress

Changes:
* Use paged reads for blobs
* Create partition level abstraction
* write directly to the file channel


TODO:
* Finish implementation of FileAppendOnlyStore, Partitions etc...
* read cache for lookups
* unit test Partitions, Blobs and Pages
* Integration and performance testing