### PR TITLE
Fix file descriptor leak in Files.list method. Stream must be closed.

### DIFF
--- a/src/main/java/com/upserve/uppend/FileStore.java
+++ b/src/main/java/com/upserve/uppend/FileStore.java
@@ -125,9 +125,8 @@ abstract class FileStore<T extends Partition> implements AutoCloseable, Register
     }
 
     Stream<T> streamPartitions() {
-        try {
-            Files
-                    .list(partitionsDir)
+        try (Stream<Path> stream = Files.list(partitionsDir)){
+            stream
                     .map(path -> path.toFile().getName())
                     .forEach(partition -> partitionMap.computeIfAbsent(
                             partition,


### PR DESCRIPTION

Bug Fix:
* Close Files.list stream which leaks open file descriptor if the stream is not closed.
