### PR TITLE
Avoid re-registering Gauge metrics

### DIFF
--- a/src/main/java/com/upserve/uppend/AppendOnlyStoreBuilder.java
+++ b/src/main/java/com/upserve/uppend/AppendOnlyStoreBuilder.java
@@ -50,7 +50,7 @@ public class AppendOnlyStoreBuilder extends FileStoreBuilder<AppendOnlyStoreBuil
 
     public AppendOnlyStore build(boolean readOnly) {
         AppendOnlyStore store = new FileAppendOnlyStore(readOnly, this);
-        if (isStoreMetrics()) store = new AppendOnlyStoreWithMetrics(store, getStoreMetricsRegistry(), getMetricsRootName());
+        if (isStoreMetrics()) store = new AppendOnlyStoreWithMetrics(store, getStoreMetricsRegistry(), getMetricsRootName(), getMetricsInstanceID());
         return store;
     }
 

--- a/src/main/java/com/upserve/uppend/FileStoreBuilder.java
+++ b/src/main/java/com/upserve/uppend/FileStoreBuilder.java
@@ -39,6 +39,7 @@ public class FileStoreBuilder<T extends FileStoreBuilder<T>> {
     private Path dir = null;
     private MetricRegistry storeMetricsRegistry = null;
     private String metricsRootName = "";
+    private String metricsInstanceID = null;
     private boolean storeMetrics = false;
     private MetricRegistry cacheMetricsRegistry = null;
     private boolean cacheMetrics = false;
@@ -155,6 +156,16 @@ public class FileStoreBuilder<T extends FileStoreBuilder<T>> {
         this.metricsRootName = metricsRootName;
         return (T) this;
     }
+    /**
+     * Used to differentiate multiple open instances of the same table
+     * @param metricsInstanceID the name under which to register metrics from this instance of the store
+     * @return the builder
+     */
+    @SuppressWarnings("unchecked")
+    public T withMetricsInstanceID(String metricsInstanceID) {
+        this.metricsInstanceID = metricsInstanceID;
+        return (T) this;
+    }
 
     public int getLookupHashCount() {
         return lookupHashCount;
@@ -203,6 +214,8 @@ public class FileStoreBuilder<T extends FileStoreBuilder<T>> {
     public int getPartitionCount(){ return partitionCount; }
 
     public String getMetricsRootName(){ return metricsRootName; }
+
+    public String getMetricsInstanceID(){ return metricsInstanceID; }
 
     public String getWriteLockContentString() { return writeLockContentString; }
 

--- a/src/main/java/com/upserve/uppend/cli/CommandBenchmark.java
+++ b/src/main/java/com/upserve/uppend/cli/CommandBenchmark.java
@@ -128,6 +128,7 @@ public class CommandBenchmark implements Callable<Void> {
         AppendOnlyStoreBuilder builder = Uppend.store(path)
                 .withStoreName(STORE_NAME)
                 .withMetricsRootName(ROOT_NAME)
+                .withMetricsInstanceID("default")
                 .withBlobsPerBlock(blockSize)
                 .withLongLookupHashCount(hashCount)
                 .withPartitionCount(partitionCount) // Use direct partition

--- a/src/main/java/com/upserve/uppend/metrics/AppendOnlyStoreWithMetrics.java
+++ b/src/main/java/com/upserve/uppend/metrics/AppendOnlyStoreWithMetrics.java
@@ -74,6 +74,7 @@ public class AppendOnlyStoreWithMetrics implements AppendOnlyStore {
     private final Meter scanKeysMeter;
 
     private final String rootName;
+    private final String instanceID;
 
     /**
      * Constructor for an Append only store with metrics wrapper
@@ -82,10 +83,11 @@ public class AppendOnlyStoreWithMetrics implements AppendOnlyStore {
      * @param metrics the metrics registry to use
      * @param rootName the root name for metrics from this store
      */
-    public AppendOnlyStoreWithMetrics(AppendOnlyStore store, MetricRegistry metrics, String rootName) {
+    public AppendOnlyStoreWithMetrics(AppendOnlyStore store, MetricRegistry metrics, String rootName, String instanceID) {
         this.store = store;
         this.metrics = metrics;
         this.rootName = rootName;
+        this.instanceID = instanceID;
 
         writeTimer = metrics.timer(MetricRegistry.name(rootName, UPPEND_APPEND_STORE, store.getName(), WRITE_TIMER_METRIC_NAME));
         flushTimer = metrics.timer(MetricRegistry.name(rootName, UPPEND_APPEND_STORE, store.getName(), FLUSH_TIMER_METRIC_NAME));
@@ -102,6 +104,10 @@ public class AppendOnlyStoreWithMetrics implements AppendOnlyStore {
         scanKeysMeter = metrics.meter(MetricRegistry.name(rootName, UPPEND_APPEND_STORE, store.getName(), SCAN_KEYS_METER_METRIC_NAME));
 
         setGaugeMetrics();
+    }
+
+    public AppendOnlyStoreWithMetrics(AppendOnlyStore store, MetricRegistry metrics, String rootName) {
+        this(store, metrics, rootName, null);
     }
 
     @Override
@@ -272,7 +278,11 @@ public class AppendOnlyStoreWithMetrics implements AppendOnlyStore {
 
     // Returns a unique key for this instance of the nth gague
     private String getKeyForGauge(int n) {
-        return MetricRegistry.name(rootName, UPPEND_APPEND_STORE, store.getName(), GAUGE_NAMES[n], String.valueOf(store.hashCode()));
+        if (null == instanceID) {
+            return MetricRegistry.name(rootName, UPPEND_APPEND_STORE, store.getName(), GAUGE_NAMES[n]);
+        } else {
+            return MetricRegistry.name(rootName, UPPEND_APPEND_STORE, store.getName(), GAUGE_NAMES[n], instanceID);
+        }
     }
 
     private void setGaugeMetrics() {

--- a/src/test/java/com/upserve/uppend/AppendOnlyStoreBuilderTest.java
+++ b/src/test/java/com/upserve/uppend/AppendOnlyStoreBuilderTest.java
@@ -25,7 +25,7 @@ public class AppendOnlyStoreBuilderTest {
         Path path = Paths.get("build/tmp/test/append-only-store-builder");
         SafeDeleting.removeDirectory(path);
         MetricRegistry metrics = new MetricRegistry();
-        AppendOnlyStore store = Uppend.store(path).withStoreMetrics(metrics).withMetricsRootName("Root").build(false);
+        AppendOnlyStore store = Uppend.store(path).withStoreMetrics(metrics).withMetricsRootName("Root").withMetricsInstanceID("default").build(false);
         store.flush();
         assertEquals(1, metrics.getTimers().get(MetricRegistry.name("Root", UPPEND_APPEND_STORE, store.getName(), FLUSH_TIMER_METRIC_NAME)).getCount());
     }

--- a/src/test/java/com/upserve/uppend/metrics/AppendOnlyStoreWithMetricsTest.java
+++ b/src/test/java/com/upserve/uppend/metrics/AppendOnlyStoreWithMetricsTest.java
@@ -35,7 +35,7 @@ public class AppendOnlyStoreWithMetricsTest {
         when(store.getName()).thenReturn("testStore");
         LookupDataMetrics lookupDataMetrics = new LookupDataMetrics(new LookupDataMetrics.Adders(), new LongSummaryStatistics());
         when(store.getLookupDataMetrics()).thenReturn(lookupDataMetrics);
-        instance = new AppendOnlyStoreWithMetrics(store, metrics, "MetricsRoot");
+        instance = new AppendOnlyStoreWithMetrics(store, metrics, "MetricsRoot", "default");
     }
 
     @Test
@@ -179,17 +179,17 @@ public class AppendOnlyStoreWithMetricsTest {
     @Test
     public void testGaugeMetrics() {
         // The underlying store is mocked, so just test that these are registered
-        assertEquals(0L, metrics.gauge(MetricRegistry.name("MetricsRoot", UPPEND_APPEND_STORE, store.getName(), FLUSHED_KEY_COUNT_GAUGE_METRIC_NAME, String.valueOf(store.hashCode())), null).getValue());
-        assertEquals(0L, metrics.gauge(MetricRegistry.name("MetricsRoot", UPPEND_APPEND_STORE, store.getName(), FLUSH_COUNT_GAUGE_METRIC_NAME, String.valueOf(store.hashCode())), null).getValue());
-        assertEquals(0L, metrics.gauge(MetricRegistry.name("MetricsRoot", UPPEND_APPEND_STORE, store.getName(), FLUSH_TIMER_GAUGE_METRIC_NAME, String.valueOf(store.hashCode())), null).getValue());
-        assertEquals(0L, metrics.gauge(MetricRegistry.name("MetricsRoot", UPPEND_APPEND_STORE, store.getName(), LOOKUP_MISS_COUNT_GAUGE_METRIC_NAME, String.valueOf(store.hashCode())), null).getValue());
-        assertEquals(0L, metrics.gauge(MetricRegistry.name("MetricsRoot", UPPEND_APPEND_STORE, store.getName(), LOOKUP_HIT_COUNT_GAUGE_METRIC_NAME, String.valueOf(store.hashCode())), null).getValue());
-        assertEquals(0L, metrics.gauge(MetricRegistry.name("MetricsRoot", UPPEND_APPEND_STORE, store.getName(), CACHE_MISS_COUNT_GAUGE_METRIC_NAME, String.valueOf(store.hashCode())), null).getValue());
-        assertEquals(0L, metrics.gauge(MetricRegistry.name("MetricsRoot", UPPEND_APPEND_STORE, store.getName(), CACHE_HIT_COUNT_GAUGE_METRIC_NAME, String.valueOf(store.hashCode())), null).getValue());
-        assertEquals(0L, metrics.gauge(MetricRegistry.name("MetricsRoot", UPPEND_APPEND_STORE, store.getName(), FIND_KEY_TIMER_GAUGE_METRIC_NAME, String.valueOf(store.hashCode())), null).getValue());
-        assertEquals(0.0, metrics.gauge(MetricRegistry.name("MetricsRoot", UPPEND_APPEND_STORE, store.getName(), AVG_LOOKUP_DATA_SIZE_GAUGE_METRIC_NAME, String.valueOf(store.hashCode())), null).getValue());
-        assertEquals(0L, metrics.gauge(MetricRegistry.name("MetricsRoot", UPPEND_APPEND_STORE, store.getName(), MAX_LOOKUP_DATA_SIZE_GAUGE_METRIC_NAME, String.valueOf(store.hashCode())), null).getValue());
-        assertEquals(0L, metrics.gauge(MetricRegistry.name("MetricsRoot", UPPEND_APPEND_STORE, store.getName(), SUM_LOOKUP_DATA_SIZE_GAUGE_METRIC_NAME, String.valueOf(store.hashCode())), null).getValue());
+        assertEquals(0L, metrics.gauge(MetricRegistry.name("MetricsRoot", UPPEND_APPEND_STORE, store.getName(), FLUSHED_KEY_COUNT_GAUGE_METRIC_NAME, "default"), null).getValue());
+        assertEquals(0L, metrics.gauge(MetricRegistry.name("MetricsRoot", UPPEND_APPEND_STORE, store.getName(), FLUSH_COUNT_GAUGE_METRIC_NAME, "default"), null).getValue());
+        assertEquals(0L, metrics.gauge(MetricRegistry.name("MetricsRoot", UPPEND_APPEND_STORE, store.getName(), FLUSH_TIMER_GAUGE_METRIC_NAME, "default"), null).getValue());
+        assertEquals(0L, metrics.gauge(MetricRegistry.name("MetricsRoot", UPPEND_APPEND_STORE, store.getName(), LOOKUP_MISS_COUNT_GAUGE_METRIC_NAME, "default"), null).getValue());
+        assertEquals(0L, metrics.gauge(MetricRegistry.name("MetricsRoot", UPPEND_APPEND_STORE, store.getName(), LOOKUP_HIT_COUNT_GAUGE_METRIC_NAME, "default"), null).getValue());
+        assertEquals(0L, metrics.gauge(MetricRegistry.name("MetricsRoot", UPPEND_APPEND_STORE, store.getName(), CACHE_MISS_COUNT_GAUGE_METRIC_NAME, "default"), null).getValue());
+        assertEquals(0L, metrics.gauge(MetricRegistry.name("MetricsRoot", UPPEND_APPEND_STORE, store.getName(), CACHE_HIT_COUNT_GAUGE_METRIC_NAME, "default"), null).getValue());
+        assertEquals(0L, metrics.gauge(MetricRegistry.name("MetricsRoot", UPPEND_APPEND_STORE, store.getName(), FIND_KEY_TIMER_GAUGE_METRIC_NAME, "default"), null).getValue());
+        assertEquals(0.0, metrics.gauge(MetricRegistry.name("MetricsRoot", UPPEND_APPEND_STORE, store.getName(), AVG_LOOKUP_DATA_SIZE_GAUGE_METRIC_NAME, "default"), null).getValue());
+        assertEquals(0L, metrics.gauge(MetricRegistry.name("MetricsRoot", UPPEND_APPEND_STORE, store.getName(), MAX_LOOKUP_DATA_SIZE_GAUGE_METRIC_NAME, "default"), null).getValue());
+        assertEquals(0L, metrics.gauge(MetricRegistry.name("MetricsRoot", UPPEND_APPEND_STORE, store.getName(), SUM_LOOKUP_DATA_SIZE_GAUGE_METRIC_NAME, "default"), null).getValue());
     }
 
     @Test

--- a/src/test/java/com/upserve/uppend/metrics/AppendOnlyStoreWithMetricsTest.java
+++ b/src/test/java/com/upserve/uppend/metrics/AppendOnlyStoreWithMetricsTest.java
@@ -179,17 +179,17 @@ public class AppendOnlyStoreWithMetricsTest {
     @Test
     public void testGaugeMetrics() {
         // The underlying store is mocked, so just test that these are registered
-        assertEquals(0L, metrics.gauge(MetricRegistry.name("MetricsRoot", UPPEND_APPEND_STORE, store.getName(), FLUSHED_KEY_COUNT_GAUGE_METRIC_NAME), null).getValue());
-        assertEquals(0L, metrics.gauge(MetricRegistry.name("MetricsRoot", UPPEND_APPEND_STORE, store.getName(), FLUSH_COUNT_GAUGE_METRIC_NAME), null).getValue());
-        assertEquals(0L, metrics.gauge(MetricRegistry.name("MetricsRoot", UPPEND_APPEND_STORE, store.getName(), FLUSH_TIMER_GAUGE_METRIC_NAME), null).getValue());
-        assertEquals(0L, metrics.gauge(MetricRegistry.name("MetricsRoot", UPPEND_APPEND_STORE, store.getName(), LOOKUP_MISS_COUNT_GAUGE_METRIC_NAME), null).getValue());
-        assertEquals(0L, metrics.gauge(MetricRegistry.name("MetricsRoot", UPPEND_APPEND_STORE, store.getName(), LOOKUP_HIT_COUNT_GAUGE_METRIC_NAME), null).getValue());
-        assertEquals(0L, metrics.gauge(MetricRegistry.name("MetricsRoot", UPPEND_APPEND_STORE, store.getName(), CACHE_MISS_COUNT_GAUGE_METRIC_NAME), null).getValue());
-        assertEquals(0L, metrics.gauge(MetricRegistry.name("MetricsRoot", UPPEND_APPEND_STORE, store.getName(), CACHE_HIT_COUNT_GAUGE_METRIC_NAME), null).getValue());
-        assertEquals(0L, metrics.gauge(MetricRegistry.name("MetricsRoot", UPPEND_APPEND_STORE, store.getName(), FIND_KEY_TIMER_GAUGE_METRIC_NAME), null).getValue());
-        assertEquals(0.0, metrics.gauge(MetricRegistry.name("MetricsRoot", UPPEND_APPEND_STORE, store.getName(), AVG_LOOKUP_DATA_SIZE_GAUGE_METRIC_NAME), null).getValue());
-        assertEquals(0L, metrics.gauge(MetricRegistry.name("MetricsRoot", UPPEND_APPEND_STORE, store.getName(), MAX_LOOKUP_DATA_SIZE_GAUGE_METRIC_NAME), null).getValue());
-        assertEquals(0L, metrics.gauge(MetricRegistry.name("MetricsRoot", UPPEND_APPEND_STORE, store.getName(), SUM_LOOKUP_DATA_SIZE_GAUGE_METRIC_NAME), null).getValue());
+        assertEquals(0L, metrics.gauge(MetricRegistry.name("MetricsRoot", UPPEND_APPEND_STORE, store.getName(), FLUSHED_KEY_COUNT_GAUGE_METRIC_NAME, String.valueOf(store.hashCode())), null).getValue());
+        assertEquals(0L, metrics.gauge(MetricRegistry.name("MetricsRoot", UPPEND_APPEND_STORE, store.getName(), FLUSH_COUNT_GAUGE_METRIC_NAME, String.valueOf(store.hashCode())), null).getValue());
+        assertEquals(0L, metrics.gauge(MetricRegistry.name("MetricsRoot", UPPEND_APPEND_STORE, store.getName(), FLUSH_TIMER_GAUGE_METRIC_NAME, String.valueOf(store.hashCode())), null).getValue());
+        assertEquals(0L, metrics.gauge(MetricRegistry.name("MetricsRoot", UPPEND_APPEND_STORE, store.getName(), LOOKUP_MISS_COUNT_GAUGE_METRIC_NAME, String.valueOf(store.hashCode())), null).getValue());
+        assertEquals(0L, metrics.gauge(MetricRegistry.name("MetricsRoot", UPPEND_APPEND_STORE, store.getName(), LOOKUP_HIT_COUNT_GAUGE_METRIC_NAME, String.valueOf(store.hashCode())), null).getValue());
+        assertEquals(0L, metrics.gauge(MetricRegistry.name("MetricsRoot", UPPEND_APPEND_STORE, store.getName(), CACHE_MISS_COUNT_GAUGE_METRIC_NAME, String.valueOf(store.hashCode())), null).getValue());
+        assertEquals(0L, metrics.gauge(MetricRegistry.name("MetricsRoot", UPPEND_APPEND_STORE, store.getName(), CACHE_HIT_COUNT_GAUGE_METRIC_NAME, String.valueOf(store.hashCode())), null).getValue());
+        assertEquals(0L, metrics.gauge(MetricRegistry.name("MetricsRoot", UPPEND_APPEND_STORE, store.getName(), FIND_KEY_TIMER_GAUGE_METRIC_NAME, String.valueOf(store.hashCode())), null).getValue());
+        assertEquals(0.0, metrics.gauge(MetricRegistry.name("MetricsRoot", UPPEND_APPEND_STORE, store.getName(), AVG_LOOKUP_DATA_SIZE_GAUGE_METRIC_NAME, String.valueOf(store.hashCode())), null).getValue());
+        assertEquals(0L, metrics.gauge(MetricRegistry.name("MetricsRoot", UPPEND_APPEND_STORE, store.getName(), MAX_LOOKUP_DATA_SIZE_GAUGE_METRIC_NAME, String.valueOf(store.hashCode())), null).getValue());
+        assertEquals(0L, metrics.gauge(MetricRegistry.name("MetricsRoot", UPPEND_APPEND_STORE, store.getName(), SUM_LOOKUP_DATA_SIZE_GAUGE_METRIC_NAME, String.valueOf(store.hashCode())), null).getValue());
     }
 
     @Test


### PR DESCRIPTION
This prevents name collisions when swapping between the Kinesis runner and formulator 

See HQ-8707

It needs testing on the Gastronomer side to be sure that these metrics are still meaningful
